### PR TITLE
마이페이지 기능 구현

### DIFF
--- a/src/main/java/com/sideteam/groupsaver/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/auth/controller/AuthController.java
@@ -9,6 +9,7 @@ import com.sideteam.groupsaver.domain.auth.service.OAuthLoginService;
 import com.sideteam.groupsaver.global.auth.AuthConstants;
 import com.sideteam.groupsaver.global.auth.oauth.kakao.KakaoLoginParams;
 import com.sideteam.groupsaver.global.util.CookieUtils;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -58,6 +59,13 @@ public class AuthController {
     public ResponseEntity<TokenDto> loginKakao(@RequestBody KakaoLoginParams params) {
         return ResponseEntity.ok(oAuthLoginService.login(params));
     }
+
+    @DeleteMapping("/leave")
+    public ResponseEntity<Void> leave(HttpServletRequest request, @CookieValue(AuthConstants.REFRESH_TOKEN) String refreshToken) {
+//        authTokenService.deleteMember(request, refreshToken);
+        return ResponseEntity.ok().build();
+    }
+
 
 
     private HttpHeaders createLoginTokenHeaders(final TokenDto tokenDto) {

--- a/src/main/java/com/sideteam/groupsaver/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/auth/dto/request/SignupRequest.java
@@ -1,11 +1,15 @@
 package com.sideteam.groupsaver.domain.auth.dto.request;
 
+import com.sideteam.groupsaver.domain.join.enums.DevelopCategory;
+import com.sideteam.groupsaver.domain.join.enums.HobbyCategory;
+import com.sideteam.groupsaver.domain.join.enums.JobCategory;
 import com.sideteam.groupsaver.global.auth.AuthConstants;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
+import java.util.List;
 
 public record SignupRequest(
 
@@ -23,7 +27,13 @@ public record SignupRequest(
         @NotBlank(message = "비밀번호는 공백이 아니어야 합니다")
         @Pattern(message = "비밀번호는 숫자, 영어, 특수문자를 포함해야 합니다", regexp = AuthConstants.passwordRegexp)
         @Size(min = 6, message = "비밀번호의 길이는 최소 6자 입니다")
-        String password
+        String password,
+
+        JobCategory jobCategory,
+
+        List<DevelopCategory> wantDevelopCategory,
+
+        List<HobbyCategory> wantHobbyCategory
 
 ) {
 }

--- a/src/main/java/com/sideteam/groupsaver/domain/auth/service/AuthTokenService.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/auth/service/AuthTokenService.java
@@ -6,6 +6,11 @@ import com.sideteam.groupsaver.domain.member.domain.Member;
 import com.sideteam.groupsaver.domain.member.repository.MemberRepository;
 import com.sideteam.groupsaver.global.auth.TokenService;
 import com.sideteam.groupsaver.global.auth.userdetails.CustomUserDetails;
+import com.sideteam.groupsaver.global.exception.auth.AuthErrorCode;
+import com.sideteam.groupsaver.global.exception.auth.AuthErrorException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -74,4 +79,14 @@ public class AuthTokenService {
     }
 
 
+    public void deleteMember(HttpServletRequest request, Cookie cookie) {
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            throw new AuthErrorException(AuthErrorCode.FAILED_AUTHENTICATION, "현재 로그인하지 않은 상태입니다.");
+        }
+        Member member = (Member) session.getAttribute("loginMember");
+        session.invalidate();
+        cookie.setMaxAge(0);
+        memberRepository.delete(member);
+    }
 }

--- a/src/main/java/com/sideteam/groupsaver/domain/join/domain/ClubBookmark.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/join/domain/ClubBookmark.java
@@ -1,0 +1,28 @@
+package com.sideteam.groupsaver.domain.join.domain;
+
+import com.sideteam.groupsaver.domain.member.domain.Member;
+import com.sideteam.groupsaver.domain.mypage.domain.Club;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ClubBookmark {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "club_id")
+    private Club club;
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/join/domain/HobbyBookmark.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/join/domain/HobbyBookmark.java
@@ -1,0 +1,27 @@
+package com.sideteam.groupsaver.domain.join.domain;
+
+import com.sideteam.groupsaver.domain.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class HobbyBookmark {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+//    @ManyToOne
+//    @JoinColumn(name = "hobby_id")
+//    private Hobby hobby;
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/join/domain/WantDevelop.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/join/domain/WantDevelop.java
@@ -1,0 +1,23 @@
+package com.sideteam.groupsaver.domain.join.domain;
+
+import com.sideteam.groupsaver.domain.join.enums.DevelopCategory;
+import com.sideteam.groupsaver.domain.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WantDevelop {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private DevelopCategory developCategory;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/join/domain/WantHobby.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/join/domain/WantHobby.java
@@ -1,0 +1,24 @@
+package com.sideteam.groupsaver.domain.join.domain;
+
+import com.sideteam.groupsaver.domain.join.enums.HobbyCategory;
+import com.sideteam.groupsaver.domain.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WantHobby {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private HobbyCategory hobbyCategory;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/join/enums/DevelopCategory.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/join/enums/DevelopCategory.java
@@ -1,0 +1,16 @@
+package com.sideteam.groupsaver.domain.join.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum DevelopCategory {
+    TYPE;
+
+    @JsonCreator
+    public static DevelopCategory from(String s){
+        try {
+            return DevelopCategory.valueOf(s.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid DevelopCategory: " + s);
+        }
+    }
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/join/enums/HobbyCategory.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/join/enums/HobbyCategory.java
@@ -1,0 +1,16 @@
+package com.sideteam.groupsaver.domain.join.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum HobbyCategory {
+    TYPE;
+
+    @JsonCreator
+    public static HobbyCategory from(String s) {
+        try {
+            return HobbyCategory.valueOf(s.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid HobbyCategory: " + s);
+        }
+    }
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/join/enums/JobCategory.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/join/enums/JobCategory.java
@@ -1,0 +1,16 @@
+package com.sideteam.groupsaver.domain.join.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum JobCategory {
+    TYPE;
+
+    @JsonCreator
+    public static JobCategory from(String s){
+        try {
+            return JobCategory.valueOf(s.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid JobCategory: " + s);
+        }
+    }
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/join/repository/ClubBookmarkRepository.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/join/repository/ClubBookmarkRepository.java
@@ -1,0 +1,13 @@
+package com.sideteam.groupsaver.domain.join.repository;
+
+import com.sideteam.groupsaver.domain.join.domain.ClubBookmark;
+import com.sideteam.groupsaver.domain.member.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ClubBookmarkRepository extends JpaRepository<ClubBookmark, Long> {
+    Page<ClubBookmark> findByMember(Member member, Pageable pageable);
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/join/repository/HobbyBookmarkRepository.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/join/repository/HobbyBookmarkRepository.java
@@ -1,0 +1,9 @@
+package com.sideteam.groupsaver.domain.join.repository;
+
+import com.sideteam.groupsaver.domain.join.domain.HobbyBookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HobbyBookmarkRepository extends JpaRepository<HobbyBookmark, Long> {
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/join/repository/WantDevelopRepository.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/join/repository/WantDevelopRepository.java
@@ -1,0 +1,9 @@
+package com.sideteam.groupsaver.domain.join.repository;
+
+import com.sideteam.groupsaver.domain.join.domain.WantDevelop;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WantDevelopRepository extends JpaRepository<WantDevelop, Long> {
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/join/repository/WantHobbyRepository.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/join/repository/WantHobbyRepository.java
@@ -1,0 +1,9 @@
+package com.sideteam.groupsaver.domain.join.repository;
+
+import com.sideteam.groupsaver.domain.join.domain.WantHobby;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WantHobbyRepository extends JpaRepository<WantHobby, Long> {
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/member/domain/Member.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/member/domain/Member.java
@@ -1,17 +1,20 @@
 package com.sideteam.groupsaver.domain.member.domain;
 
 import com.sideteam.groupsaver.domain.common.BaseTimeEntity;
+import com.sideteam.groupsaver.domain.join.domain.WantDevelop;
+import com.sideteam.groupsaver.domain.join.domain.WantHobby;
+import com.sideteam.groupsaver.domain.join.enums.JobCategory;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Setter
 @Entity
 public class Member extends BaseTimeEntity {
     @Id
@@ -41,14 +44,28 @@ public class Member extends BaseTimeEntity {
     )
     private Set<MemberRole> roles = new HashSet<>();
 
+    // 직무 & 자기계발 & 취미생활 데이터 받기
+    @Column
+    private JobCategory jobCategory;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<WantDevelop> wantDevelopList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<WantHobby> wantHobbyList = new ArrayList<>();
+
+
     @Builder
-    protected Member(String password, String phoneNumber, String nickname, String email, OAuthProvider oAuthProvider, Set<MemberRole> roles) {
+    protected Member(String password, String phoneNumber, String nickname, String email, OAuthProvider oAuthProvider, Set<MemberRole> roles, JobCategory jobCategory, List<WantDevelop> wantDevelopList, List<WantHobby> wantHobbyList) {
         this.password = password;
         this.phoneNumber = phoneNumber;
         this.email = email;
         this.nickname = nickname;
         this.oAuthProvider = oAuthProvider;
         this.roles = roles;
+        this.jobCategory = jobCategory;
+        this.wantDevelopList = wantDevelopList;
+        this.wantHobbyList = wantHobbyList;
     }
 
 }

--- a/src/main/java/com/sideteam/groupsaver/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/member/repository/MemberRepository.java
@@ -2,9 +2,11 @@ package com.sideteam.groupsaver.domain.member.repository;
 
 import com.sideteam.groupsaver.domain.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);

--- a/src/main/java/com/sideteam/groupsaver/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/mypage/controller/MyPageController.java
@@ -1,0 +1,52 @@
+package com.sideteam.groupsaver.domain.mypage.controller;
+
+import com.sideteam.groupsaver.domain.mypage.dto.request.MyInfoUpdateRequest;
+import com.sideteam.groupsaver.domain.mypage.dto.response.ClubFindResponse;
+import com.sideteam.groupsaver.domain.mypage.dto.response.MyInfoFindResponse;
+import com.sideteam.groupsaver.domain.mypage.service.MyPageService;
+import com.sideteam.groupsaver.global.auth.userdetails.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/mypage")
+public class MyPageController {
+
+    private final MyPageService myPageService;
+
+    /**
+     * 내 정보 조회
+     * 내 정보 수정 ( 직무 수정,  관심사 ( 자기계발, 취미 ) 수정 )
+     * 내 모임 목록
+     * 찜한 모임 목록
+     *
+     * 회원 가입시 직무 & 자기계발 & 취미생활 데이터 받기
+     * 탈퇴
+     */
+
+    @GetMapping("/myinfo/search")
+    public ResponseEntity<MyInfoFindResponse> findMyInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(myPageService.findMyInfo(userDetails.getId()));
+    }
+
+    @PutMapping("/myinfo/update")
+    public ResponseEntity<MyInfoFindResponse> updateMyInfo(@RequestBody @Valid MyInfoUpdateRequest dto,
+                                                             @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(myPageService.updateMyInfo(dto, userDetails.getId()));
+    }
+
+    @GetMapping("/clubs/my")
+    public ResponseEntity<Page<ClubFindResponse>> findMyClub(@RequestParam(required = false) Boolean star,
+                                                             @AuthenticationPrincipal CustomUserDetails userDetails,
+                                                             @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(myPageService.findMyClub(star, userDetails.getId(), pageable));
+    }
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/mypage/domain/Club.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/mypage/domain/Club.java
@@ -1,0 +1,32 @@
+package com.sideteam.groupsaver.domain.mypage.domain;
+
+import com.sideteam.groupsaver.domain.common.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@Getter
+@Entity
+public class Club extends BaseTimeEntity { // Enum 사용 전
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String location;
+    private Long memberNumMax;
+    private String type;
+    private String description;
+    private Long category;
+    private String mainImage;
+    private Boolean status;
+    private String period;
+    private LocalDateTime startClub;
+    private String activityType;
+}
+

--- a/src/main/java/com/sideteam/groupsaver/domain/mypage/dto/request/MyInfoUpdateRequest.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/mypage/dto/request/MyInfoUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.sideteam.groupsaver.domain.mypage.dto.request;
+
+import com.sideteam.groupsaver.domain.join.enums.DevelopCategory;
+import com.sideteam.groupsaver.domain.join.enums.HobbyCategory;
+import com.sideteam.groupsaver.domain.join.enums.JobCategory;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MyInfoUpdateRequest {
+    private String nickname;
+    private JobCategory jobCategory;
+    private List<HobbyCategory> hobbyCategory;
+    private List<DevelopCategory> developCategory;
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/mypage/dto/response/ClubFindResponse.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/mypage/dto/response/ClubFindResponse.java
@@ -1,0 +1,45 @@
+package com.sideteam.groupsaver.domain.mypage.dto.response;
+
+import com.sideteam.groupsaver.domain.mypage.domain.Club;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ClubFindResponse {
+    private Long id;
+    private String name;
+    private String location;
+    private Long memberNumMax;
+    private String type;
+    private String description;
+    private Long category;
+    private String mainImage;
+    private Boolean status;
+    private String period;
+    private LocalDateTime startClub;
+    private String activityType;
+
+    @Builder
+    public static ClubFindResponse toDto(Club club) {
+        return ClubFindResponse.builder()
+                .id(club.getId())
+                .name(club.getName())
+                .location(club.getLocation())
+                .memberNumMax(club.getMemberNumMax())
+                .type(club.getType())
+                .category(club.getCategory())
+                .mainImage(club.getMainImage())
+                .status(club.getStatus())
+                .period(club.getPeriod())
+                .startClub(club.getStartClub())
+                .activityType(club.getActivityType())
+                .build();
+    }
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/mypage/dto/response/MyInfoFindResponse.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/mypage/dto/response/MyInfoFindResponse.java
@@ -1,0 +1,31 @@
+package com.sideteam.groupsaver.domain.mypage.dto.response;
+
+import com.sideteam.groupsaver.domain.member.domain.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MyInfoFindResponse {
+
+    private Long id;
+    private String password;
+    private String phoneNumber;
+    private String nickname;
+    private String email;
+
+    @Builder
+    public static MyInfoFindResponse toDto(Member member) {
+        return MyInfoFindResponse.builder()
+                .id(member.getId())
+                .password(member.getPassword())
+                .phoneNumber(member.getPhoneNumber())
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .build();
+    }
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/mypage/repository/ClubRepository.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/mypage/repository/ClubRepository.java
@@ -1,0 +1,13 @@
+package com.sideteam.groupsaver.domain.mypage.repository;
+
+import com.sideteam.groupsaver.domain.member.domain.Member;
+import com.sideteam.groupsaver.domain.mypage.domain.Club;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ClubRepository extends JpaRepository<Club, Long> {
+    Page<Club> findByMember(Member member, Pageable pageable);
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/mypage/service/MyPageService.java
@@ -1,0 +1,113 @@
+package com.sideteam.groupsaver.domain.mypage.service;
+
+import com.sideteam.groupsaver.domain.join.domain.ClubBookmark;
+import com.sideteam.groupsaver.domain.join.domain.WantDevelop;
+import com.sideteam.groupsaver.domain.join.domain.WantHobby;
+import com.sideteam.groupsaver.domain.join.enums.DevelopCategory;
+import com.sideteam.groupsaver.domain.join.enums.HobbyCategory;
+import com.sideteam.groupsaver.domain.join.repository.ClubBookmarkRepository;
+import com.sideteam.groupsaver.domain.join.repository.HobbyBookmarkRepository;
+import com.sideteam.groupsaver.domain.join.repository.WantDevelopRepository;
+import com.sideteam.groupsaver.domain.join.repository.WantHobbyRepository;
+import com.sideteam.groupsaver.domain.member.domain.Member;
+import com.sideteam.groupsaver.domain.member.repository.MemberRepository;
+import com.sideteam.groupsaver.domain.mypage.domain.Club;
+import com.sideteam.groupsaver.domain.mypage.dto.request.MyInfoUpdateRequest;
+import com.sideteam.groupsaver.domain.mypage.dto.response.ClubFindResponse;
+import com.sideteam.groupsaver.domain.mypage.dto.response.MyInfoFindResponse;
+import com.sideteam.groupsaver.domain.mypage.repository.ClubRepository;
+import com.sideteam.groupsaver.global.exception.auth.AuthErrorCode;
+import com.sideteam.groupsaver.global.exception.auth.AuthErrorException;
+import com.sideteam.groupsaver.global.exception.club.ClubErrorCode;
+import com.sideteam.groupsaver.global.exception.club.ClubErrorException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
+public class MyPageService {
+    private final ClubRepository clubRepository;
+    private final MemberRepository memberRepository;
+    private final WantDevelopRepository wantDevelopRepository;
+    private final WantHobbyRepository wantHobbyRepository;
+    private final ClubBookmarkRepository clubBookmarkRepository;
+    private final HobbyBookmarkRepository hobbyBookmarkRepository;
+
+
+    @Transactional
+    public MyInfoFindResponse findMyInfo(Long id) {
+        Member member = findMember(id);
+        return MyInfoFindResponse.toDto(member);
+    }
+
+    @Transactional
+    public MyInfoFindResponse updateMyInfo(MyInfoUpdateRequest dto, Long id) {
+        Member member = findMember(id);
+        if(dto.getNickname() != null)
+            member.setNickname(dto.getNickname());
+
+        if(dto.getJobCategory() != null)
+            member.setJobCategory(dto.getJobCategory());
+
+        for(HobbyCategory hobbyCategory : dto.getHobbyCategory()){
+            WantHobby wantHobby = WantHobby.builder()
+                    .hobbyCategory(hobbyCategory)
+                    .member(member)
+                    .build();
+            wantHobbyRepository.save(wantHobby);
+        }
+
+        for(DevelopCategory developCategory : dto.getDevelopCategory()){
+            WantDevelop wantDevelop = WantDevelop.builder()
+                    .developCategory(developCategory)
+                    .member(member)
+                    .build();
+            wantDevelopRepository.save(wantDevelop);
+        }
+
+        return MyInfoFindResponse.toDto(member);
+    }
+
+    @Transactional
+    public Page<ClubFindResponse> findMyClub(Boolean star, Long id, Pageable pageable) {
+        Member member = findMember(id);
+
+        Page<Club> result;
+        if(star){
+            Page<ClubBookmark> clubPage = clubBookmarkRepository.findByMember(member, pageable);
+
+            List<Club> clubs = clubPage.getContent().stream()
+                    .map(ClubBookmark::getClub)
+                    .collect(Collectors.toList());
+
+            result = new PageImpl<>(clubs, clubPage.getPageable(), clubPage.getTotalElements());
+        }else{
+            result = clubRepository.findByMember(member, pageable);
+        }
+        List<ClubFindResponse> clubResponses = result.getContent().stream()
+                .map(ClubFindResponse::toDto)
+                .collect(Collectors.toList());
+
+        return new PageImpl<>(clubResponses, result.getPageable(), result.getTotalElements());
+    }
+
+
+    private Member findMember(Long id){
+        return memberRepository.findById(id).orElseThrow(()
+                -> new AuthErrorException(AuthErrorCode.FAILED_AUTHENTICATION, "로그인한 멤버정보를 가져올 수 없습니다."));
+    }
+
+    private Club findClub(Long id){
+        return clubRepository.findById(id).orElseThrow(()
+                -> new ClubErrorException(ClubErrorCode.NOT_FOUND_CLUB, "모임을 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/com/sideteam/groupsaver/global/exception/club/ClubErrorCode.java
+++ b/src/main/java/com/sideteam/groupsaver/global/exception/club/ClubErrorCode.java
@@ -1,0 +1,27 @@
+package com.sideteam.groupsaver.global.exception.club;
+
+import com.sideteam.groupsaver.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@RequiredArgsConstructor
+@Getter
+public enum ClubErrorCode implements ErrorCode {
+
+    // 404
+    NOT_FOUND_CLUB(NOT_FOUND, "모임을 찾을 수 없습니다.")
+
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String detail;
+
+    @Override
+    public String getName() {
+        return this.name();
+    }
+}
+

--- a/src/main/java/com/sideteam/groupsaver/global/exception/club/ClubErrorException.java
+++ b/src/main/java/com/sideteam/groupsaver/global/exception/club/ClubErrorException.java
@@ -1,0 +1,20 @@
+package com.sideteam.groupsaver.global.exception.club;
+
+import lombok.Getter;
+
+@Getter
+public class ClubErrorException extends RuntimeException {
+
+    private final ClubErrorCode errorCode;
+    private final String causedBy;
+
+    public ClubErrorException(ClubErrorCode errorCode, String causedBy) {
+        this.errorCode = errorCode;
+        this.causedBy = causedBy;
+    }
+
+    @Override
+    public String toString() {
+        return "CLUB 에러 코드: " + errorCode + ", 사유: " + causedBy;
+    }
+}


### PR DESCRIPTION
## 이슈 연결
- #15 

## 구현한 API
- `DELETE /api/v1/auth/leave` 
- `GET /api/v1/mypage/myinfo/search` 
- `PUT /api/v1/mypage/myinfo/update`
- `GET /api/v1/mypage/clubs/my`

## 작업 사항
### 회원 탈퇴
- `HttpServletRequest`로 헤더와 세션 정보를 받아와 `session.invalidate()` 및 `cookie.setMaxAge(0)`로 초기화
- 특정 쿠키와 헤더를 지우는게 더 나을 것 같아 방법 탐색중..

### 마이페이지 구현
- 각 엔티티간 일대다/다대일 연결
- 직무, 자기계발, 취미를 `Enum`으로 구현해서 api 기능 개발 

## 리뷰 요청 사항
코드에 중복부분이 많아서 임의로 구현한 부분이 꽤 있습니다. 각 기능 구현에 있어서 부족한 부분이 있다면 지적 부탁드려요!
