### PR TITLE
로그인 토큰 DTO 반환 방식 수정 & 공통 에러 반환 로직 구현

### DIFF
--- a/src/main/java/com/sideteam/groupsaver/domain/auth/dto/request/TokenRefreshRequest.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/auth/dto/request/TokenRefreshRequest.java
@@ -1,0 +1,9 @@
+package com.sideteam.groupsaver.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TokenRefreshRequest(
+        @NotBlank
+        String refreshToken
+) {
+}

--- a/src/main/java/com/sideteam/groupsaver/global/auth/entrypoint/AuthEntryPointJwt.java
+++ b/src/main/java/com/sideteam/groupsaver/global/auth/entrypoint/AuthEntryPointJwt.java
@@ -5,25 +5,28 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
 
 import java.io.IOException;
 
-@RequiredArgsConstructor
 @Slf4j
 @Component
 public class AuthEntryPointJwt implements AuthenticationEntryPoint {
 
+    private final HandlerExceptionResolver resolver;
+
+    public AuthEntryPointJwt(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
+        this.resolver = resolver;
+    }
+
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
-            throws IOException {
-
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-
-        // TODO 에러 값 생성 후 반환
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) {
+        resolver.resolveException(request, response, null, authException);
     }
 
 }

--- a/src/main/java/com/sideteam/groupsaver/global/config/ObjectMapperConfig.java
+++ b/src/main/java/com/sideteam/groupsaver/global/config/ObjectMapperConfig.java
@@ -1,15 +1,20 @@
 package com.sideteam.groupsaver.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Objects;
 
 @Configuration
 public class ObjectMapperConfig {
 
     @Bean
     public ObjectMapper objectMapper() {
-        return new ObjectMapper();
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        return objectMapper;
     }
 
 }

--- a/src/main/java/com/sideteam/groupsaver/global/config/security/SecurityFilterConfig.java
+++ b/src/main/java/com/sideteam/groupsaver/global/config/security/SecurityFilterConfig.java
@@ -1,6 +1,6 @@
 package com.sideteam.groupsaver.global.config.security;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sideteam.groupsaver.global.auth.entrypoint.AuthEntryPointJwt;
 import com.sideteam.groupsaver.global.auth.jwt.JwtTokenProvider;
 import com.sideteam.groupsaver.global.auth.userdetails.UserDetailsServiceImpl;
 import com.sideteam.groupsaver.global.filter.AuthenticationCheckFilter;
@@ -16,11 +16,11 @@ class SecurityFilterConfig {
     private final UserDetailsServiceImpl userDetailsService;
 
     private final JwtTokenProvider jwtTokenProvider;
-    private final ObjectMapper objectMapper;
+    private final AuthEntryPointJwt authEntryPointJwt;
 
     @Bean
     public AuthenticationCheckFilter authenticationCheckFilter() {
-        return new AuthenticationCheckFilter(userDetailsService, jwtTokenProvider, objectMapper);
+        return new AuthenticationCheckFilter(userDetailsService, jwtTokenProvider, authEntryPointJwt);
     }
 
 }

--- a/src/main/java/com/sideteam/groupsaver/global/exception/ApiErrorCode.java
+++ b/src/main/java/com/sideteam/groupsaver/global/exception/ApiErrorCode.java
@@ -1,0 +1,27 @@
+package com.sideteam.groupsaver.global.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public enum ApiErrorCode implements ErrorCode {
+
+    FAILED_VALIDATION(BAD_REQUEST, "Request is invalid and falls outside the valid range"),
+    SERVER_ERROR(INTERNAL_SERVER_ERROR, "Internal server error"),
+
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String detail;
+
+    @Override
+    public String getName() {
+        return this.name();
+    }
+}

--- a/src/main/java/com/sideteam/groupsaver/global/exception/ApiErrorResponse.java
+++ b/src/main/java/com/sideteam/groupsaver/global/exception/ApiErrorResponse.java
@@ -1,0 +1,53 @@
+package com.sideteam.groupsaver.global.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+public class ApiErrorResponse {
+    private final String path;
+    private final int statusCode;
+    private final String error;
+    private final String codeName;
+    private final String detail;
+    private final String reason;
+
+    public static ResponseEntity<ApiErrorResponse> toResponseEntity(
+            @NotNull ErrorCode errorCode,
+            Exception exception,
+            HttpServletRequest request
+    ) {
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(of(errorCode, exception, request));
+    }
+
+    private static ApiErrorResponse of(
+            @NotNull ErrorCode errorCode,
+            Exception exception,
+            HttpServletRequest request
+    ) {
+        return ApiErrorResponse.builder()
+                .path(request.getServletPath())
+                .statusCode(errorCode.getHttpStatus().value())
+                .error(errorCode.getHttpStatus().name())
+                .codeName(errorCode.getName())
+                .detail(errorCode.getDetail())
+                .reason(exception.getMessage())
+                .build();
+    }
+
+    @Builder
+    private ApiErrorResponse(String path, int statusCode, String error, String codeName, String detail, String reason) {
+        this.path = path;
+        this.statusCode = statusCode;
+        this.error = error;
+        this.codeName = codeName;
+        this.detail = detail;
+        this.reason = reason;
+    }
+}

--- a/src/main/java/com/sideteam/groupsaver/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sideteam/groupsaver/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,60 @@
+package com.sideteam.groupsaver.global.exception;
+
+import com.sideteam.groupsaver.global.exception.auth.AuthErrorCode;
+import com.sideteam.groupsaver.global.exception.auth.AuthErrorException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(AuthErrorException.class)
+    public ResponseEntity<ApiErrorResponse> handleAuthErrorException(AuthErrorException ex, HttpServletRequest request) {
+        return ApiErrorResponse.toResponseEntity(ex.getErrorCode(), ex, request);
+    }
+
+    @ExceptionHandler(UsernameNotFoundException.class)
+    public ResponseEntity<ApiErrorResponse> handleUsernameNotFoundException(UsernameNotFoundException ex, HttpServletRequest request) {
+        return ApiErrorResponse.toResponseEntity(AuthErrorCode.FAILED_AUTHENTICATION, ex, request);
+    }
+
+    @ExceptionHandler(BadCredentialsException.class) // 비밀번호가 틀린 경우
+    public ResponseEntity<ApiErrorResponse> handleBadCredentialsException(BadCredentialsException ex, HttpServletRequest request) {
+        return ApiErrorResponse.toResponseEntity(AuthErrorCode.FAILED_AUTHENTICATION, ex, request);
+    }
+
+    @ExceptionHandler(InternalAuthenticationServiceException.class) // 내부적으로 인증 처리를 할 수 없는 경우
+    public ResponseEntity<ApiErrorResponse> handleInternalAuthenticationServiceException(InternalAuthenticationServiceException ex, HttpServletRequest request) {
+        return ApiErrorResponse.toResponseEntity(AuthErrorCode.FAILED_AUTHENTICATION, ex, request);
+    }
+
+    @ExceptionHandler(InsufficientAuthenticationException.class)
+    public ResponseEntity<ApiErrorResponse> handleHttpClientErrorException(InsufficientAuthenticationException ex, HttpServletRequest request) {
+        return ApiErrorResponse.toResponseEntity(AuthErrorCode.FAILED_AUTHENTICATION, ex, request);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex, HttpServletRequest request) {
+        return ApiErrorResponse.toResponseEntity(ApiErrorCode.FAILED_VALIDATION, ex, request);
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ApiErrorResponse> handleException(Exception ex, HttpServletRequest request) {
+        log.error("GlobalExceptionHandler에 정의되지 않은 에러: " + ex.toString());
+        return ApiErrorResponse.toResponseEntity(ApiErrorCode.SERVER_ERROR, ex, request);
+    }
+
+}

--- a/src/main/java/com/sideteam/groupsaver/global/exception/auth/AuthErrorException.java
+++ b/src/main/java/com/sideteam/groupsaver/global/exception/auth/AuthErrorException.java
@@ -1,14 +1,16 @@
 package com.sideteam.groupsaver.global.exception.auth;
 
 import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
 
 @Getter
-public class AuthErrorException extends RuntimeException {
+public class AuthErrorException extends AuthenticationException {
 
     private final AuthErrorCode errorCode;
     private final String causedBy;
 
     public AuthErrorException(AuthErrorCode errorCode, String causedBy) {
+        super(causedBy, null);
         this.errorCode = errorCode;
         this.causedBy = causedBy;
     }


### PR DESCRIPTION
## 이슈 연결

- #17 

## 구현한 API

- 따로 새롭게 구현한 API는 없고 로그인과 토큰 재발행 API들의 response 반환 코드와 body 형식 수정만 있습니다

## 작업 사항

### 로그인
access 토큰과 refresh 토큰 반환 방식이 변경되었습니다. 

기존에는 authorization 헤더와 set-cookie 헤더에 담아서 클라이언트로 토큰들을 보냈는데, 새롭게 response body에 담아서 보내도록 바꾸었습니다.

```json
{
    "accessToken": "eyJ...",
    "refreshToken": "bb3...",
    "type": "Bearer "
}
```

### 전역 예외 처리 핸들러 추가

- `@ControllerAdvise`를 사용해 에러 처리

- 아래와 같은 형식으로 반환될 예정입니다.

- e.g. 잘못된 토큰이 Authorization 헤더에 담겨서 요청된 경우, 반환 형태

  ```json
  {
      "path": "/api/v1/test",
      "statusCode": 401,
      "error": "UNAUTHORIZED",
      "codeName": "TAMPERED_ACCESS_TOKEN",
      "detail": "서명이 조작된 토큰입니다",
      "reason": "JWT signature does not match locally computed signature. JWT validity cannot be asserted and should not be trusted."
  }
  ```

## 리뷰 요청 사항

기존에 refresh 토큰을 쿠키에 저장하도록 했었는데 이 부분을 바꿨습니다. 그래서 토큰 재발급시, 클라이언트가 request body에 refresh 토큰을 담아서 보내도록 했는데 이 부분이 어색하면 변경해도 좋을 것 같습니다!

```java
@PostMapping("/token")
public ResponseEntity<TokenDto> refreshToken(
        @Valid @RequestBody TokenRefreshRequest refreshTokenRequest
) {
```

이외에도 어색한 코드들 편하게 의견 주시면 감사하겠습니다!
