### PR TITLE
회원가입에 필요한 데이터 추가 & 랜덤 닉네임 생성기

### DIFF
--- a/src/main/java/com/sideteam/groupsaver/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/auth/dto/request/SignupRequest.java
@@ -1,14 +1,19 @@
 package com.sideteam.groupsaver.domain.auth.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.sideteam.groupsaver.domain.category.domain.ClubCategoryMajor;
 import com.sideteam.groupsaver.domain.category.domain.JobMajor;
 import com.sideteam.groupsaver.global.auth.AuthConstants;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
+import java.time.LocalDate;
 import java.util.List;
+
+import static com.sideteam.groupsaver.global.util.ProjectTimeFormat.*;
 
 public record SignupRequest(
 
@@ -29,6 +34,17 @@ public record SignupRequest(
         String password,
 
         JobMajor jobCategory,
+
+        String gender,
+
+        @Schema(description = "생년월일", example = LOCAL_DATE_PATTERN_EXAMPLE, type = "string")
+        @JsonFormat(pattern = LOCAL_DATE_PATTERN)
+        LocalDate birth,
+
+        boolean ageTerm,
+        boolean serviceTerm,
+        boolean userInfoTerm,
+        boolean locationTerm,
 
         List<ClubCategoryMajor> categories
 ) {

--- a/src/main/java/com/sideteam/groupsaver/domain/auth/service/AuthSignupService.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/auth/service/AuthSignupService.java
@@ -2,20 +2,24 @@ package com.sideteam.groupsaver.domain.auth.service;
 
 import com.sideteam.groupsaver.domain.auth.dto.request.SignupRequest;
 import com.sideteam.groupsaver.domain.auth.dto.response.SignupResult;
+import com.sideteam.groupsaver.domain.category.domain.ClubCategory;
+import com.sideteam.groupsaver.domain.category.domain.ClubCategoryMajor;
+import com.sideteam.groupsaver.domain.join.domain.WantClubCategory;
+import com.sideteam.groupsaver.domain.join.repository.WantClubCategoryRepository;
 import com.sideteam.groupsaver.domain.member.domain.Member;
 import com.sideteam.groupsaver.domain.member.domain.MemberRole;
 import com.sideteam.groupsaver.domain.member.domain.OAuthProvider;
 import com.sideteam.groupsaver.domain.member.repository.MemberRepository;
 import com.sideteam.groupsaver.global.exception.BusinessException;
-import com.sideteam.groupsaver.global.exception.auth.AuthErrorCode;
-import com.sideteam.groupsaver.global.exception.auth.AuthErrorException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.sideteam.groupsaver.global.exception.member.MemberErrorCode.DUPLICATED_EMAIL;
 
@@ -23,10 +27,9 @@ import static com.sideteam.groupsaver.global.exception.member.MemberErrorCode.DU
 @Slf4j
 @Service
 public class AuthSignupService {
-
     private final MemberRepository memberRepository;
+    private final WantClubCategoryRepository categoryRepository;
     private final PasswordEncoder passwordEncoder;
-
 
     @Transactional
     public SignupResult signup(final SignupRequest signupRequest) {
@@ -41,7 +44,14 @@ public class AuthSignupService {
                 .password(encodePassword(signupRequest))
                 .phoneNumber(signupRequest.phoneNumber())
                 .jobCategory(signupRequest.jobCategory())
+                .gender(signupRequest.gender())
+                .birth(signupRequest.birth())
+                .serviceTerm(signupRequest.serviceTerm())
+                .ageTerm(signupRequest.ageTerm())
+                .locationTerm(signupRequest.locationTerm())
+                .userInfoTerm(signupRequest.userInfoTerm())
                 .build();
+        createWantClubCategories(signupRequest.categories(), member);
         memberRepository.save(member);
 
         log.info("회원가입 완료: ID: {}, 이메일: {}, 닉네임: {}", member.getId(), member.getEmail(), member.getNickname());
@@ -61,4 +71,11 @@ public class AuthSignupService {
         return passwordEncoder.encode(signupRequest.password());
     }
 
+    private void createWantClubCategories(List<ClubCategoryMajor> clubCategoryMajors, Member member) {
+        member.updateWantClubCategory(
+                categoryRepository.saveAll(
+                        clubCategoryMajors.stream().map(major -> WantClubCategory.of(member, major)).collect(Collectors.toList())
+                )
+        );
+    }
 }

--- a/src/main/java/com/sideteam/groupsaver/domain/member/domain/Member.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/member/domain/Member.java
@@ -38,7 +38,8 @@ public class Member extends BaseTimeEntity {
     private String email;
 
     private LocalDate birth;
-    private String profileUrl;
+    private String gender;
+    private String profileUrl = "https://sabuzac-bucket.s3.ap-northeast-2.amazonaws.com/user/profile_default_image/profile.png";
 
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)
@@ -58,9 +59,13 @@ public class Member extends BaseTimeEntity {
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, orphanRemoval = true)
     private final List<WantClubCategory> wantClubCategories = new ArrayList<>();
 
+    private boolean ageTerm;
+    private boolean serviceTerm;
+    private boolean userInfoTerm;
+    private boolean locationTerm;
 
     @Builder
-    protected Member(String password, String phoneNumber, String nickname, String email, OAuthProvider oAuthProvider, Set<MemberRole> roles, JobMajor jobCategory) {
+    protected Member(String password, String phoneNumber, String nickname, String email, OAuthProvider oAuthProvider, Set<MemberRole> roles, JobMajor jobCategory, String gender, LocalDate birth, boolean ageTerm, boolean locationTerm, boolean serviceTerm, boolean userInfoTerm) {
         this.password = password;
         this.phoneNumber = phoneNumber;
         this.email = email;
@@ -68,6 +73,12 @@ public class Member extends BaseTimeEntity {
         this.oAuthProvider = oAuthProvider;
         this.roles = roles;
         this.jobCategory = jobCategory;
+        this.gender = gender;
+        this.birth = birth;
+        this.ageTerm = ageTerm;
+        this.serviceTerm = serviceTerm;
+        this.locationTerm = locationTerm;
+        this.userInfoTerm = userInfoTerm;
     }
 
     public void update(MyInfoUpdateRequest myInfoUpdateRequest) {
@@ -78,5 +89,7 @@ public class Member extends BaseTimeEntity {
     }
 
 
-
+    public void updateWantClubCategory(List<WantClubCategory> categories) {
+        this.wantClubCategories.addAll(categories);
+    }
 }

--- a/src/main/java/com/sideteam/groupsaver/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/member/repository/MemberRepository.java
@@ -4,8 +4,10 @@ import com.sideteam.groupsaver.domain.member.domain.Member;
 import com.sideteam.groupsaver.global.exception.BusinessException;
 import com.sideteam.groupsaver.global.exception.member.MemberErrorCode;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -21,4 +23,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     }
 
     boolean existsByNickname(String nickname);
+
+    @Query("SELECT COUNT(*) FROM Member m WHERE LOWER(REPLACE(m.nickname, ' ', '')) = LOWER(REPLACE(:nickname, ' ', ''))")
+    Long countByNickname(String nickname);
 }

--- a/src/main/java/com/sideteam/groupsaver/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/member/repository/MemberRepository.java
@@ -20,4 +20,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
                 -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND, "멤버 정보를 가져올 수 없습니다."));
     }
 
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/sideteam/groupsaver/domain/randomNickname/controller/NicknameController.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/randomNickname/controller/NicknameController.java
@@ -1,0 +1,24 @@
+package com.sideteam.groupsaver.domain.randomNickname.controller;
+
+import com.sideteam.groupsaver.domain.randomNickname.dto.NicknameResponseDto;
+import com.sideteam.groupsaver.domain.randomNickname.service.NicknameService;
+import com.sideteam.groupsaver.global.config.swagger.DisableSwaggerSecurity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/nickname")
+public class NicknameController {
+    private final NicknameService nickNameService;
+
+    @DisableSwaggerSecurity
+    @GetMapping("/getNickname")
+    public ResponseEntity<NicknameResponseDto> getNickName() {
+        return new ResponseEntity<NicknameResponseDto>(nickNameService.createNickName(), HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/randomNickname/controller/NicknameController.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/randomNickname/controller/NicknameController.java
@@ -22,10 +22,11 @@ public class NicknameController {
 
     @DisableSwaggerSecurity
     @PostMapping("/checkDuplication")
-    public ResponseEntity<Boolean> checkNickname(@RequestBody nickNameDto nickname) {
+    public ResponseEntity<Boolean> checkNickname(@RequestBody NickNameDto nickname) {
         return ResponseEntity.ok(nickNameService.checkNickname(nickname.get()));
     }
-    record nickNameDto(
+
+    record NickNameDto(
             String nickname
     ) {
         public String get() {

--- a/src/main/java/com/sideteam/groupsaver/domain/randomNickname/controller/NicknameController.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/randomNickname/controller/NicknameController.java
@@ -6,9 +6,7 @@ import com.sideteam.groupsaver.global.config.swagger.DisableSwaggerSecurity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,6 +17,20 @@ public class NicknameController {
     @DisableSwaggerSecurity
     @GetMapping("/getNickname")
     public ResponseEntity<NicknameResponseDto> getNickName() {
-        return new ResponseEntity<NicknameResponseDto>(nickNameService.createNickName(), HttpStatus.CREATED);
+        return new ResponseEntity<>(nickNameService.createNickName(), HttpStatus.CREATED);
     }
+
+    @DisableSwaggerSecurity
+    @PostMapping("/checkDuplication")
+    public ResponseEntity<Boolean> checkNickname(@RequestBody nickNameDto nickname) {
+        return ResponseEntity.ok(nickNameService.checkNickname(nickname.get()));
+    }
+    record nickNameDto(
+            String nickname
+    ) {
+        public String get() {
+            return nickname;
+        }
+    }
+
 }

--- a/src/main/java/com/sideteam/groupsaver/domain/randomNickname/domain/NicknameAD.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/randomNickname/domain/NicknameAD.java
@@ -1,0 +1,17 @@
+package com.sideteam.groupsaver.domain.randomNickname.domain;
+
+import com.sideteam.groupsaver.domain.common.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Entity(name = "nickname_ad")
+@Getter
+public class NicknameAD extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    private String ad;
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/randomNickname/domain/NicknameNoun.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/randomNickname/domain/NicknameNoun.java
@@ -1,0 +1,17 @@
+package com.sideteam.groupsaver.domain.randomNickname.domain;
+
+import com.sideteam.groupsaver.domain.common.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class NicknameNoun extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    private String noun;
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/randomNickname/dto/NicknameResponseDto.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/randomNickname/dto/NicknameResponseDto.java
@@ -1,0 +1,23 @@
+package com.sideteam.groupsaver.domain.randomNickname.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NicknameResponseDto {
+    private String nickName;
+
+    @Builder
+    private NicknameResponseDto(String nickName) {
+        this.nickName = nickName;
+    }
+
+    public static NicknameResponseDto of(String nickName) {
+        return NicknameResponseDto.builder()
+                .nickName(nickName)
+                .build();
+    }
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/randomNickname/repository/RandomNicknameADResource.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/randomNickname/repository/RandomNicknameADResource.java
@@ -1,0 +1,10 @@
+package com.sideteam.groupsaver.domain.randomNickname.repository;
+
+import com.sideteam.groupsaver.domain.randomNickname.domain.NicknameAD;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface RandomNicknameADResource extends JpaRepository<NicknameAD, Long> {
+    @Query("SELECT n.ad FROM nickname_ad n WHERE n.id = :id")
+    String findAdById(long id);
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/randomNickname/repository/RandomNicknameNounResource.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/randomNickname/repository/RandomNicknameNounResource.java
@@ -1,0 +1,10 @@
+package com.sideteam.groupsaver.domain.randomNickname.repository;
+
+import com.sideteam.groupsaver.domain.randomNickname.domain.NicknameNoun;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface RandomNicknameNounResource extends JpaRepository<NicknameNoun, Long> {
+    @Query("SELECT n.noun FROM NicknameNoun n WHERE n.id = :id")
+    String findNounById(long id);
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/randomNickname/service/NicknameService.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/randomNickname/service/NicknameService.java
@@ -25,4 +25,8 @@ public class NicknameService {
         } while (memberRepository.existsByNickname(nickname));
         return NicknameResponseDto.of(nickname);
     }
+
+    public boolean checkNickname(String nickname) {
+        return memberRepository.countByNickname(nickname) == 0;
+    }
 }

--- a/src/main/java/com/sideteam/groupsaver/domain/randomNickname/service/NicknameService.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/randomNickname/service/NicknameService.java
@@ -1,0 +1,28 @@
+package com.sideteam.groupsaver.domain.randomNickname.service;
+
+import com.sideteam.groupsaver.domain.member.repository.MemberRepository;
+import com.sideteam.groupsaver.domain.randomNickname.dto.NicknameResponseDto;
+import com.sideteam.groupsaver.domain.randomNickname.repository.RandomNicknameADResource;
+import com.sideteam.groupsaver.domain.randomNickname.repository.RandomNicknameNounResource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class NicknameService {
+    private final RandomNicknameNounResource nounResource;
+    private final RandomNicknameADResource adResource;
+    private final MemberRepository memberRepository;
+
+    // 만약 조합할 수 있는 단어롤 다 사용했다면 어떻게 처리할것인가
+    public NicknameResponseDto createNickName() {
+        String nickname;
+        do {
+            nickname = adResource.findAdById(new Random().nextLong(10) + 1) +
+                    nounResource.findNounById(new Random().nextLong(10) + 1);
+        } while (memberRepository.existsByNickname(nickname));
+        return NicknameResponseDto.of(nickname);
+    }
+}

--- a/src/main/java/com/sideteam/groupsaver/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/sideteam/groupsaver/global/config/security/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
             // API
             "/api/v1/auth/**",
             "/api/v1/test/**",
+            "/api/v1/nickname/**",
 
             // Swagger
             "/v3/api-docs/**",

--- a/src/main/resources/dml.sql
+++ b/src/main/resources/dml.sql
@@ -9,3 +9,26 @@ INSERT INTO default_main_image (url) VALUES ('test7');
 INSERT INTO default_main_image (url) VALUES ('test8');
 INSERT INTO default_main_image (url) VALUES ('test9');
 INSERT INTO default_main_image (url) VALUES ('test0');
+
+
+INSERT INTO nickname_ad (ad) VALUES ('똑똑한 ');
+INSERT INTO nickname_ad (ad) VALUES ('즐거운 ');
+INSERT INTO nickname_ad (ad) VALUES ('재미난 ');
+INSERT INTO nickname_ad (ad) VALUES ('현명한 ');
+INSERT INTO nickname_ad (ad) VALUES ('멋있는 ');
+INSERT INTO nickname_ad (ad) VALUES ('배고픈 ');
+INSERT INTO nickname_ad (ad) VALUES ('퇴근한 ');
+INSERT INTO nickname_ad (ad) VALUES ('출근한 ');
+INSERT INTO nickname_ad (ad) VALUES ('야근한 ');
+INSERT INTO nickname_ad (ad) VALUES ('당직인 ');
+
+INSERT INTO nickname_noun (noun) VALUES ('대리');
+INSERT INTO nickname_noun (noun) VALUES ('과장');
+INSERT INTO nickname_noun (noun) VALUES ('부장');
+INSERT INTO nickname_noun (noun) VALUES ('이사');
+INSERT INTO nickname_noun (noun) VALUES ('사원');
+INSERT INTO nickname_noun (noun) VALUES ('팀장');
+INSERT INTO nickname_noun (noun) VALUES ('사수');
+INSERT INTO nickname_noun (noun) VALUES ('주임');
+INSERT INTO nickname_noun (noun) VALUES ('차장');
+INSERT INTO nickname_noun (noun) VALUES ('인턴');


### PR DESCRIPTION
## 이슈 연결

- #42 

## 구현한 API
- 닉네임 랜덤 생성기 : /api/v1/nickname/getNickname
- 중복 닉네임 조회 : /api/v1/nickname/checkDuplication

## 수정한 API
- 회원가입 : localhost:8080/api/v1/auth/signup

## 작업 사항
회원가입시 필요한 데이터( 성별, 생년월일, 자기개발, 취미 ) 추가
멤버에 기본프로필 이미지 고정
랜덤 닉네임 생성기 개발
중복 닉네임 조회 api 개발

## 리뷰 요청 사항
닉네임 랜덤 생성기를 일단 만들긴 했는데 만약 조합할 수 있는 단어를 다 사용했다면 어떻게 해야할지를 같이 생각해주시면 감사하겠습니다!

