### PR TITLE
모임 채팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/sideteam/groupsaver/domain/chat/Chat.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/chat/Chat.java
@@ -1,0 +1,47 @@
+package com.sideteam.groupsaver.domain.chat;
+
+import com.sideteam.groupsaver.domain.chat.dto.MessageType;
+import com.sideteam.groupsaver.domain.club.domain.Club;
+import com.sideteam.groupsaver.domain.common.BaseTimeEntity;
+import com.sideteam.groupsaver.domain.member.domain.Member;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(indexes = @Index(name = "IDX_CLUB_ID", columnList = "club_id"))
+@Entity
+public class Chat extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private Club club;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private Member sender;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MessageType type;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Builder
+    protected Chat(Club club, Member sender, @NotBlank String content, MessageType type) {
+        this.club = club;
+        this.sender = sender;
+        this.content = content;
+        this.type = type;
+    }
+
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/chat/ChatController.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/chat/ChatController.java
@@ -1,0 +1,50 @@
+package com.sideteam.groupsaver.domain.chat;
+
+import com.sideteam.groupsaver.domain.chat.dto.request.ChatRequest;
+import com.sideteam.groupsaver.domain.chat.dto.response.ChatResponse;
+import com.sideteam.groupsaver.global.resolver.member_info.MemberIdParam;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.*;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.Map;
+
+import static com.sideteam.groupsaver.global.websocket.WebSocketUtils.DEFAULT_CLUB_CHAT_PATH;
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+@Slf4j
+@RequiredArgsConstructor
+@Controller
+public class ChatController {
+
+    private final ChatService chatService;
+
+    @ResponseBody
+    @GetMapping("/api/v1/clubs/{clubId}/chats")
+    public ResponseEntity<Page<ChatResponse>> getClubChatting(
+            @PathVariable(name = "clubId") Long clubId,
+            @MemberIdParam Long memberId,
+            @PageableDefault(sort = "createAt", direction = DESC) Pageable pageable) {
+
+        return ResponseEntity.ok(chatService.getAllChatsByClub(clubId, memberId, pageable));
+    }
+
+    @MessageMapping("/chats/clubs/{clubId}")
+    @SendTo(DEFAULT_CLUB_CHAT_PATH + "{clubId}")
+    public ChatResponse sendMessage(@DestinationVariable("clubId") Long clubId,
+                                    @Header("simpSessionAttributes") Map<String, Object> simpSessionAttributes,
+                                    @Payload ChatRequest chatRequest
+    ) {
+        log.debug("모임: {}, {}, re: {}", clubId, simpSessionAttributes, chatRequest);
+        return chatService.save(chatRequest, clubId, simpSessionAttributes);
+    }
+
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/chat/ChatRepository.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/chat/ChatRepository.java
@@ -1,0 +1,13 @@
+package com.sideteam.groupsaver.domain.chat;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface ChatRepository extends JpaRepository<Chat, Long> {
+
+    @Query("SELECT ch FROM Chat ch JOIN FETCH Member m ON ch.sender = m WHERE ch.club.id=:clubId")
+    Page<Chat> findAllByClubId(Long clubId, Pageable pageable);
+
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/chat/ChatService.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/chat/ChatService.java
@@ -1,0 +1,69 @@
+package com.sideteam.groupsaver.domain.chat;
+
+import com.sideteam.groupsaver.domain.chat.dto.WebSocketIdentity;
+import com.sideteam.groupsaver.domain.chat.dto.request.ChatRequest;
+import com.sideteam.groupsaver.domain.chat.dto.response.ChatResponse;
+import com.sideteam.groupsaver.domain.club.domain.Club;
+import com.sideteam.groupsaver.domain.member.domain.Member;
+import com.sideteam.groupsaver.global.websocket.WebSocketUtils;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class ChatService {
+
+    private final ChatRepository chatRepository;
+    private final EntityManager entityManager;
+
+    @Transactional
+    public ChatResponse save(ChatRequest chatRequest, Long clubId, Map<String, Object> header) {
+        Chat chat = chatRepository.save(toChat(chatRequest, clubId));
+
+        return toChatResponse(chat, header);
+    }
+
+    @PreAuthorize("@authorityChecker.hasAuthority(#memberId, @clubMemberRepository.isInClub(#clubId, #memberId))")
+    public Page<ChatResponse> getAllChatsByClub(Long clubId, Long memberId, Pageable pageable) {
+        return chatRepository.findAllByClubId(clubId, pageable).map(ChatResponse::of);
+    }
+
+
+    private Chat toChat(ChatRequest chatRequest, Long clubId) {
+        log.info("{}", chatRequest);
+        return Chat.builder()
+                .content(chatRequest.content())
+                .type(chatRequest.type())
+                .club(entityManager.getReference(Club.class, clubId))
+                .sender(entityManager.getReference(Member.class, chatRequest.memberId()))
+                .build();
+    }
+
+
+    private ChatResponse toChatResponse(Chat chat, Map<String, Object> header) {
+        WebSocketIdentity identity = getValueFromHeader(header, WebSocketUtils.IDENTITY);
+
+        return ChatResponse.builder()
+                .nickname(identity.nickname())
+                .profileImgUrl(identity.profileUrl())
+                .type(chat.getType())
+                .content(chat.getContent())
+                .createdAt(chat.getCreatedAtLocalDateTime())
+                .build();
+    }
+
+    private <T> T getValueFromHeader(Map<String, Object> header, String key) {
+        return (T) header.get(key);
+    }
+
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/chat/dto/MessageType.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/chat/dto/MessageType.java
@@ -1,0 +1,7 @@
+package com.sideteam.groupsaver.domain.chat.dto;
+
+public enum MessageType {
+    JOIN,
+    CHAT,
+    LEAVE
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/chat/dto/WebSocketIdentity.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/chat/dto/WebSocketIdentity.java
@@ -1,0 +1,8 @@
+package com.sideteam.groupsaver.domain.chat.dto;
+
+public record WebSocketIdentity(
+        Long memberId,
+        String nickname,
+        String profileUrl
+) {
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/chat/dto/request/ChatRequest.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/chat/dto/request/ChatRequest.java
@@ -1,0 +1,10 @@
+package com.sideteam.groupsaver.domain.chat.dto.request;
+
+import com.sideteam.groupsaver.domain.chat.dto.MessageType;
+
+public record ChatRequest(
+        MessageType type,
+        Long memberId,
+        String content
+) {
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/chat/dto/response/ChatResponse.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/chat/dto/response/ChatResponse.java
@@ -1,0 +1,29 @@
+package com.sideteam.groupsaver.domain.chat.dto.response;
+
+import com.sideteam.groupsaver.domain.chat.Chat;
+import com.sideteam.groupsaver.domain.chat.dto.MessageType;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record ChatResponse(
+        Long memberId,
+        String nickname,
+        String profileImgUrl,
+        MessageType type,
+        LocalDateTime createdAt,
+        String content
+) {
+    public static ChatResponse of(Chat chat) {
+        return ChatResponse.builder()
+                .memberId(chat.getSender().getId())
+                .nickname(chat.getSender().getNickname())
+                .profileImgUrl(chat.getSender().getProfileUrl())
+                .type(chat.getType())
+                .createdAt(chat.getCreatedAtLocalDateTime())
+                .content(chat.getContent())
+                .build();
+    }
+
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/club/repository/ClubMemberRepository.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/club/repository/ClubMemberRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.function.BooleanSupplier;
+
 import static com.sideteam.groupsaver.global.exception.club.ClubErrorCode.CLUB_MEMBER_DO_NOT_HAVE_PERMISSION;
 
 public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
@@ -38,6 +40,10 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
 
     default boolean isLeader(Long clubId, Long memberId) {
         return hasClubRole(clubId, memberId, ClubMemberRole.LEADER);
+    }
+
+    default BooleanSupplier isInClub(Long clubId, Long memberId) {
+        return () -> existsByClubIdAndMemberId(clubId, memberId);
     }
 
 }

--- a/src/main/java/com/sideteam/groupsaver/domain/common/BaseTimeEntity.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/common/BaseTimeEntity.java
@@ -9,6 +9,8 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 @Getter
 @ToString
@@ -21,4 +23,9 @@ public abstract class BaseTimeEntity {
 
     @LastModifiedDate
     private Instant updateAt;
+
+    public LocalDateTime getCreatedAtLocalDateTime() {
+        return LocalDateTime.ofInstant(createAt, ZoneId.systemDefault());
+    }
+
 }

--- a/src/main/java/com/sideteam/groupsaver/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/sideteam/groupsaver/global/auth/jwt/JwtTokenProvider.java
@@ -49,7 +49,7 @@ public final class JwtTokenProvider {
      * @param headerAuth - 헤더 문자열
      * @return - 추출한 JWT 토큰
      */
-    private static String parseJwt(final String headerAuth) {
+    public static String parseJwt(final String headerAuth) {
 
         if (StringUtils.hasText(headerAuth) && headerAuth.startsWith(AuthConstants.TOKEN_TYPE)) {
             return headerAuth.substring(AuthConstants.TOKEN_TYPE.length()).trim();

--- a/src/main/java/com/sideteam/groupsaver/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/sideteam/groupsaver/global/config/security/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
             "/api/v1/auth/**",
             "/api/v1/test/**",
             "/api/v1/nickname/**",
+            "/ws/**",
 
             // Swagger
             "/v3/api-docs/**",

--- a/src/main/java/com/sideteam/groupsaver/global/exception/websocket/WebSocketErrorCode.java
+++ b/src/main/java/com/sideteam/groupsaver/global/exception/websocket/WebSocketErrorCode.java
@@ -1,0 +1,27 @@
+package com.sideteam.groupsaver.global.exception.websocket;
+
+import com.sideteam.groupsaver.global.exception.ErrorCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public enum WebSocketErrorCode implements ErrorCode {
+
+    FAILED_CONVERT(INTERNAL_SERVER_ERROR, "Failed to convert data"),
+    SESSION_IS_NULL(INTERNAL_SERVER_ERROR, "Session is null"),
+
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String detail;
+
+    @Override
+    public String getName() {
+        return this.name();
+    }
+}

--- a/src/main/java/com/sideteam/groupsaver/global/websocket/WebSocketAuthInterceptor.java
+++ b/src/main/java/com/sideteam/groupsaver/global/websocket/WebSocketAuthInterceptor.java
@@ -1,0 +1,112 @@
+package com.sideteam.groupsaver.global.websocket;
+
+import com.sideteam.groupsaver.domain.chat.dto.WebSocketIdentity;
+import com.sideteam.groupsaver.domain.club.repository.ClubMemberRepository;
+import com.sideteam.groupsaver.domain.member.domain.Member;
+import com.sideteam.groupsaver.domain.member.repository.MemberRepository;
+import com.sideteam.groupsaver.global.auth.jwt.JwtTokenProvider;
+import com.sideteam.groupsaver.global.exception.BusinessException;
+import com.sideteam.groupsaver.global.exception.club.ClubErrorCode;
+import jakarta.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+import static com.sideteam.groupsaver.global.websocket.WebSocketUtils.DEFAULT_CLUB_CHAT_PATH;
+
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class WebSocketAuthInterceptor implements ChannelInterceptor {
+
+    private final MemberRepository memberRepository;
+    private final ClubMemberRepository clubMemberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public Message<?> preSend(@Nonnull Message<?> message, @Nonnull MessageChannel channel) {
+        final StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        Objects.requireNonNull(accessor, "accessor is null");
+
+        final StompCommand stompCommand = accessor.getCommand();
+        Objects.requireNonNull(stompCommand, "stompCommand is null");
+
+        switch (stompCommand) {
+            case CONNECT:
+            case SEND:
+                setIdentity(accessor);
+                break;
+
+            case SUBSCRIBE:
+                handleSubscribe(accessor);
+                break;
+
+            case DISCONNECT:
+                handleDisconnect(accessor);
+                break;
+        }
+
+        return message;
+    }
+
+
+    private void setIdentity(final StompHeaderAccessor accessor) {
+        Member member = getMemberFromToken(accessor.getFirstNativeHeader(HttpHeaders.AUTHORIZATION));
+        log.info("MEMBER: {}, {}", member, accessor.getFirstNativeHeader(HttpHeaders.AUTHORIZATION));
+        WebSocketIdentity identity = new WebSocketIdentity(member.getId(), member.getNickname(), member.getProfileUrl());
+        WebSocketUtils.setValue(accessor, WebSocketUtils.IDENTITY, identity);
+    }
+
+    private void handleSubscribe(final StompHeaderAccessor accessor) {
+        WebSocketIdentity identity = WebSocketUtils.getValue(accessor, WebSocketUtils.IDENTITY);
+        Long clubId = parseClubIdFromPath(accessor);
+        log.info("identity : {} clubId : {}", identity.memberId(), clubId);
+        WebSocketUtils.setValue(accessor, "clubId", clubId);
+        validateMemberInClub(identity.memberId(), clubId);
+    }
+
+    private void handleDisconnect(final StompHeaderAccessor accessor) {
+        WebSocketIdentity identity = WebSocketUtils.getValue(accessor, WebSocketUtils.IDENTITY);
+        log.info("DISCONNECT {}", identity);
+    }
+
+    private String getToken(String tokenHeader) {
+        return JwtTokenProvider.parseJwt(tokenHeader);
+    }
+
+    private Member getMemberFromToken(String tokenHeader) {
+        String accessToken = getToken(tokenHeader);
+        String subject = jwtTokenProvider.getSubject(accessToken);
+
+        return memberRepository.findByIdOrThrow(Long.parseLong(subject));
+    }
+
+
+    private void validateMemberInClub(Long memberId, Long clubId) {
+        if (!clubMemberRepository.existsByClubIdAndMemberId(clubId, memberId)) {
+            throw new BusinessException(ClubErrorCode.CLUB_MEMBER_DO_NOT_HAVE_PERMISSION, memberId.toString());
+        }
+    }
+
+    private Long parseClubIdFromPath(StompHeaderAccessor accessor) {
+        String destination = accessor.getDestination();
+        if (destination == null || !destination.startsWith(DEFAULT_CLUB_CHAT_PATH)) {
+            throw new IllegalArgumentException("Invalid destination path");
+        }
+        try {
+            return Long.parseLong(destination.substring(DEFAULT_CLUB_CHAT_PATH.length()));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid club ID in the path");
+        }
+    }
+
+}

--- a/src/main/java/com/sideteam/groupsaver/global/websocket/WebSocketConfig.java
+++ b/src/main/java/com/sideteam/groupsaver/global/websocket/WebSocketConfig.java
@@ -1,0 +1,35 @@
+package com.sideteam.groupsaver.global.websocket;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@RequiredArgsConstructor
+@EnableWebSocketMessageBroker
+@Configuration
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final WebSocketAuthInterceptor webSocketAuthInterceptor;
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.setApplicationDestinationPrefixes("/app");
+        registry.enableSimpleBroker("/chatroom", "/user");
+        registry.setUserDestinationPrefix("/user");
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(webSocketAuthInterceptor);
+    }
+
+}

--- a/src/main/java/com/sideteam/groupsaver/global/websocket/WebSocketUtils.java
+++ b/src/main/java/com/sideteam/groupsaver/global/websocket/WebSocketUtils.java
@@ -1,0 +1,50 @@
+package com.sideteam.groupsaver.global.websocket;
+
+import com.sideteam.groupsaver.global.exception.BusinessException;
+import com.sideteam.groupsaver.global.exception.websocket.WebSocketErrorCode;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+import java.util.Map;
+import java.util.Objects;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class WebSocketUtils {
+
+    public static final String IDENTITY = "identity";
+    public static final String DEFAULT_CLUB_CHAT_PATH = "/chatroom/clubs/";
+
+
+    public static <T> T getValue(StompHeaderAccessor accessor, String key) {
+        Map<String, Object> sessionAttributes = getSessionAttributes(accessor);
+        Object value = sessionAttributes.get(key);
+
+        if (Objects.isNull(value)) {
+            throw new BusinessException(WebSocketErrorCode.SESSION_IS_NULL, key + " : not found");
+        }
+
+        try {
+            return (T) value;
+        } catch (Exception exception) {
+            throw new BusinessException(WebSocketErrorCode.FAILED_CONVERT, key);
+        }
+    }
+
+    public static void setValue(StompHeaderAccessor accessor, String key, Object value) {
+        Map<String, Object> sessionAttributes = getSessionAttributes(accessor);
+        sessionAttributes.put(key, value);
+    }
+
+
+    public static Map<String, Object> getSessionAttributes(StompHeaderAccessor accessor) {
+        Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+
+        if (Objects.isNull(sessionAttributes)) {
+            throw new BusinessException(WebSocketErrorCode.SESSION_IS_NULL, "session is null");
+        }
+        return sessionAttributes;
+    }
+
+
+}


### PR DESCRIPTION
## 이슈 연결

- close #49 

## 구현한 API

- GET `/api/v1/clubs/{clubId}/chats` : 해당 모임 채팅 내역 페이징 해서 가져오기
- send `/ws/app/chats/clubs/{clubId}` : 해당 모임에 채팅 보내기 ( 해당 모임에 가입한 상태여야 함 )
- subscribe `/ws/chatroom/clubs/{clubId}` : 실시간 모임 채팅 내역 수신하겠다고 서버에 등록하기

## 작업 사항

- STOMP를 사용한 모임 채팅 구현

```js
const chatRequest = {
            content: "보낼 채팅 메세지",
            type: 'CHAT', // 현재는 CHAT으로 고정
            memberId: 1 // 보내는 사용자 id( 자기 자신 )
};
```

- 모든 요청에는 header에 JWT 토큰이 포함되어 있어야함

- 요청 헤더 예시
```json
{ "Authorization": "ez~ jwt 토큰" } 
```


- 응답 json 예시
  -  createdAt은 채팅을 작성한 일자
```json
{
  "memberId": 1,
  "nickname": "닉네임",
  "profileImgUrl": "https://~ 멤버 프로필 url",
  "type": "CHAT",
  "createdAt": "2024-03-11T07:18:27.598Z",
  "content": "넘어온 메세지"
}
```

## 리뷰 요청 사항

