### PR TITLE
온라인 모임에 기본 주소가 저장되는 사항 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,14 @@
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.1.4'
     id 'io.spring.dependency-management' version '1.1.4'
 }
 
-def buildTimestamp = new Date().format('yyyy-MM-dd\'T\'HH-mm-ss zzz')
+
+def buildTimestamp = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).getDateTimeString()
 def appVersion = '1.0.0'
 
 springBoot {
@@ -59,9 +63,8 @@ dependencies {
     runtimeOnly "io.jsonwebtoken:jjwt-impl:0.11.5"
     runtimeOnly "io.jsonwebtoken:jjwt-jackson:0.11.5"
 
-    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.522' // AWS SDK
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.658' // AWS SDK
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0' // Swagger
-
 
 
     // QueryDSL
@@ -76,13 +79,12 @@ dependencies {
 
     //slack
     implementation("net.gpedro.integrations.slack:slack-webhook:1.4.0")
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
 
     testImplementation 'org.testcontainers:testcontainers:1.19.3'
     testImplementation 'org.testcontainers:junit-jupiter:1.19.3'
     testImplementation 'org.testcontainers:jdbc:1.19.3'
     testImplementation "org.testcontainers:mysql:1.19.3"
-    testImplementation 'org.signal:embedded-redis:0.8.3'
-    implementation 'com.google.firebase:firebase-admin:9.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sideteam/groupsaver/domain/category/domain/ClubCategory.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/category/domain/ClubCategory.java
@@ -1,8 +1,15 @@
 package com.sideteam.groupsaver.domain.category.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.sideteam.groupsaver.global.exception.BusinessException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+import static com.sideteam.groupsaver.global.exception.category.CategoryErrorCode.INVALID_CATEGORY;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
@@ -13,5 +20,19 @@ public enum ClubCategory {
     ;
 
     private final String type;
+
+
+    @JsonCreator
+    public static ClubCategory of(final String type) {
+        return Arrays.stream(values())
+                .filter(value -> value.type.equals(type))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(INVALID_CATEGORY, type + ", 존재하지 않는 카테고리입니다."));
+    }
+
+    @JsonValue
+    public String getJsonValue() {
+        return type;
+    }
 
 }

--- a/src/main/java/com/sideteam/groupsaver/domain/category/domain/ClubCategoryMajor.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/category/domain/ClubCategoryMajor.java
@@ -1,10 +1,15 @@
 package com.sideteam.groupsaver.domain.category.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.sideteam.groupsaver.global.exception.BusinessException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.Optional;
+
 import static com.sideteam.groupsaver.domain.category.domain.ClubCategory.DEVELOP;
 import static com.sideteam.groupsaver.domain.category.domain.ClubCategory.HOBBY;
 import static com.sideteam.groupsaver.global.exception.category.CategoryErrorCode.CATEGORY_MAJOR_NOT_FOUND;
@@ -40,16 +45,20 @@ public enum ClubCategoryMajor {
     private final ClubCategory category;
     private final String name;
 
+
     @JsonCreator
-    public static ClubCategoryMajor getClubCategoryMajor(String major) {
-        if (major == null) {
-            return null;
-        }
-        for (ClubCategoryMajor clubCategoryMajor : ClubCategoryMajor.values()) {
-            if (clubCategoryMajor.getName().equals(major)) {
-                return clubCategoryMajor;
-            }
-        }
-        throw new BusinessException(CATEGORY_MAJOR_NOT_FOUND, CATEGORY_MAJOR_NOT_FOUND.getDetail());
+    public static ClubCategoryMajor getClubCategoryMajor(final String major) {
+        return Optional.ofNullable(major)
+                .map(m -> Arrays.stream(ClubCategoryMajor.values())
+                        .filter(clubCategoryMajor -> clubCategoryMajor.name.equals(m))
+                        .findFirst()
+                        .orElseThrow(() -> new BusinessException(CATEGORY_MAJOR_NOT_FOUND, major + ", 해당하는 카테고리가 없습니다.")))
+                .orElse(null);
     }
+
+    @JsonValue
+    public String getJsonValue() {
+        return name;
+    }
+
 }

--- a/src/main/java/com/sideteam/groupsaver/domain/category/domain/ClubCategorySub.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/category/domain/ClubCategorySub.java
@@ -1,10 +1,15 @@
 package com.sideteam.groupsaver.domain.category.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.sideteam.groupsaver.global.exception.BusinessException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.Optional;
+
 import static com.sideteam.groupsaver.global.exception.category.CategoryErrorCode.CATEGORY_SUB_NOT_FOUND;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -98,16 +103,19 @@ public enum ClubCategorySub {
         return this.major.getCategory();
     }
 
+
     @JsonCreator
-    public static ClubCategorySub getClubCategorySub(String sub) {
-        if (sub == null) {
-            return null;
-        }
-        for (ClubCategorySub clubCategorySub : ClubCategorySub.values()) {
-            if (clubCategorySub.getName().equals(sub)) {
-                return clubCategorySub;
-            }
-        }
-        throw new BusinessException(CATEGORY_SUB_NOT_FOUND, CATEGORY_SUB_NOT_FOUND.getDetail());
+    public static ClubCategorySub getClubCategorySub(final String sub) {
+        return Optional.ofNullable(sub)
+                .flatMap(s -> Arrays.stream(ClubCategorySub.values())
+                        .filter(clubCategorySub -> clubCategorySub.name.equals(s))
+                        .findFirst())
+                .orElseThrow(() -> new BusinessException(CATEGORY_SUB_NOT_FOUND, sub + ", 해당 카테고리가 존재하지 않습니다."));
     }
+
+    @JsonValue
+    public String getJsonValue() {
+        return this.etc ? "기타" : this.name;
+    }
+
 }

--- a/src/main/java/com/sideteam/groupsaver/domain/category/domain/JobMajor.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/category/domain/JobMajor.java
@@ -1,11 +1,17 @@
 package com.sideteam.groupsaver.domain.category.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.sideteam.groupsaver.global.exception.BusinessException;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.Optional;
 
 import static com.sideteam.groupsaver.global.exception.category.CategoryErrorCode.CATEGORY_MAJOR_NOT_FOUND;
 
+@RequiredArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 @Getter
 public enum JobMajor {
     MANAGEMENT("기획 · 전략 · 경영"),
@@ -28,25 +34,25 @@ public enum JobMajor {
     LAW("법률 · 법무직"),
     PUBLIC("공공 · 복지"),
     SERVICE("서비스직"),
-    ETC("기타")
+    ETC("기타"),
     ;
 
-    private final String category;
+    private final String name;
 
-    JobMajor(String category) {
-        this.category = category;
-    }
 
     @JsonCreator
-    public static JobMajor getJobMajor(String major) {
-        if (major == null) {
-            return null;
-        }
-        for (JobMajor jobMajor : JobMajor.values()) {
-            if (jobMajor.getCategory().equals(major)) {
-                return jobMajor;
-            }
-        }
-        throw new BusinessException(CATEGORY_MAJOR_NOT_FOUND, CATEGORY_MAJOR_NOT_FOUND.getDetail());
+    public static JobMajor getJobMajor(final String major) {
+        return Optional.ofNullable(major)
+                .map(m -> Arrays.stream(JobMajor.values())
+                        .filter(jobMajor -> jobMajor.name.equals(m))
+                        .findFirst()
+                        .orElseThrow(() -> new BusinessException(CATEGORY_MAJOR_NOT_FOUND, major + ", 해당 직종을 찾을 수 없습니다.")))
+                .orElse(null);
     }
+
+    @JsonValue
+    public String getJsonValue() {
+        return name;
+    }
+
 }

--- a/src/main/java/com/sideteam/groupsaver/domain/club/domain/Club.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/club/domain/Club.java
@@ -70,6 +70,7 @@ public class Club extends BaseEntity {
     @Column(nullable = false)
     private Integer randomId = (int) (Math.random() * 100_000_000);
 
+    @Column(nullable = false)
     private Integer memberMaxNumber;
 
     @Formula("(SELECT COUNT(*) FROM club_member cm WHERE cm.club_id = id AND cm.status = 'ACTIVITY')")
@@ -82,7 +83,7 @@ public class Club extends BaseEntity {
     private final List<ReportClub> reports = new ArrayList<>();
 
 
-    public static Club of(ClubRequest clubRequest, Location location) {
+    public static Club of(ClubRequest clubRequest) {
         ClubCategoryMajor categoryMajor = clubRequest.getMajor();
         return Club.builder()
                 .name(clubRequest.name())
@@ -96,9 +97,14 @@ public class Club extends BaseEntity {
                 .categorySub(clubRequest.categorySub())
                 .type(clubRequest.type())
                 .activityType(clubRequest.activityType())
-                .location(location)
-                .locationDetail(clubRequest.locationDetail())
                 .build();
+    }
+
+    public static Club of(ClubRequest clubRequest, Location location) {
+        Club club = of(clubRequest);
+        club.location = location;
+        club.locationDetail = clubRequest.locationDetail();
+        return club;
     }
 
 

--- a/src/main/java/com/sideteam/groupsaver/domain/club/domain/Club.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/club/domain/Club.java
@@ -102,6 +102,9 @@ public class Club extends BaseEntity {
 
     public static Club of(ClubRequest clubRequest, Location location) {
         Club club = of(clubRequest);
+        if (ClubActivityType.ONLINE.equals(club.activityType)) { // 온라인 모임은 위치 정보 저장을 생략
+            return club;
+        }
         club.location = location;
         club.locationDetail = clubRequest.locationDetail();
         return club;

--- a/src/main/java/com/sideteam/groupsaver/domain/club/domain/ClubActivityType.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/club/domain/ClubActivityType.java
@@ -1,12 +1,13 @@
 package com.sideteam.groupsaver.domain.club.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.sideteam.groupsaver.domain.category.domain.ClubCategorySub;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.sideteam.groupsaver.global.exception.BusinessException;
 import lombok.Getter;
 
+import java.util.Arrays;
+
 import static com.sideteam.groupsaver.global.exception.category.CategoryErrorCode.ACTIVITY_TYPE_NOT_FOUND;
-import static com.sideteam.groupsaver.global.exception.category.CategoryErrorCode.CATEGORY_SUB_NOT_FOUND;
 
 @Getter
 public enum ClubActivityType {
@@ -20,13 +21,18 @@ public enum ClubActivityType {
         this.activityType = activityType;
     }
 
+
     @JsonCreator
-    public static ClubActivityType getClubActivityType(String activityType) {
-        for (ClubActivityType clubCategorySub : ClubActivityType.values()) {
-            if (clubCategorySub.getActivityType().equals(activityType)) {
-                return clubCategorySub;
-            }
-        }
-        throw new BusinessException(ACTIVITY_TYPE_NOT_FOUND, ACTIVITY_TYPE_NOT_FOUND.getDetail());
+    public static ClubActivityType getClubActivityType(final String activityType) {
+        return Arrays.stream(ClubActivityType.values())
+                .filter(clubCategorySub -> clubCategorySub.getActivityType().equals(activityType))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(ACTIVITY_TYPE_NOT_FOUND, activityType + ", 해당하는 활동 유형을 찾을 수 없습니다."));
     }
+
+    @JsonValue
+    public String getJsonValue() {
+        return activityType;
+    }
+
 }

--- a/src/main/java/com/sideteam/groupsaver/domain/club/domain/ClubMemberRole.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/club/domain/ClubMemberRole.java
@@ -1,5 +1,6 @@
 package com.sideteam.groupsaver.domain.club.domain;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 
 @Getter
@@ -12,4 +13,11 @@ public enum ClubMemberRole {
     ClubMemberRole(String clubMemberRole) {
         this.clubMemberRole = clubMemberRole;
     }
+
+
+    @JsonValue
+    public String getJsonValue() {
+        return clubMemberRole;
+    }
+
 }

--- a/src/main/java/com/sideteam/groupsaver/domain/club/domain/ClubType.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/club/domain/ClubType.java
@@ -1,17 +1,19 @@
 package com.sideteam.groupsaver.domain.club.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.sideteam.groupsaver.global.exception.BusinessException;
 import lombok.Getter;
 
-import static com.sideteam.groupsaver.global.exception.category.CategoryErrorCode.CATEGORY_SUB_NOT_FOUND;
+import java.util.Arrays;
+
 import static com.sideteam.groupsaver.global.exception.category.CategoryErrorCode.CLUB_TYPE_NOT_FOUND;
 
 @Getter
 public enum ClubType {
     SHORT("단기"),
     LONG("장기"),
-    ONE("원데이")
+    ONE("원데이"),
     ;
 
     private final String type;
@@ -20,13 +22,18 @@ public enum ClubType {
         this.type = type;
     }
 
+
     @JsonCreator
     public static ClubType getClubType(String type) {
-        for (ClubType clubType : ClubType.values()) {
-            if (clubType.getType().equals(type)) {
-                return clubType;
-            }
-        }
-        throw new BusinessException(CLUB_TYPE_NOT_FOUND, CLUB_TYPE_NOT_FOUND.getDetail());
+        return Arrays.stream(ClubType.values())
+                .filter(clubType -> clubType.getType().equals(type))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(CLUB_TYPE_NOT_FOUND, CLUB_TYPE_NOT_FOUND.getDetail()));
     }
+
+    @JsonValue
+    public String getJsonValue() {
+        return type;
+    }
+
 }

--- a/src/main/java/com/sideteam/groupsaver/domain/club/dto/request/ClubRequest.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/club/dto/request/ClubRequest.java
@@ -11,11 +11,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import org.hibernate.validator.constraints.Length;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
 
 import static com.sideteam.groupsaver.global.util.ProjectTimeFormat.LOCAL_DATE_TIME_PATTERN;
 import static com.sideteam.groupsaver.global.util.ProjectTimeFormat.LOCAL_DATE_TIME_PATTERN_EXAMPLE;
@@ -52,6 +50,14 @@ public record ClubRequest(
     public boolean isCategoryAtLeastExist() {
         return categoryMajor != null || categorySub != null;
     }
+
+    @Hidden
+    @AssertTrue(message = "오프라인 모임은 위치 정보가 필수입니다")
+    public boolean isOfflineClubAndHasLocation() {
+        return ClubActivityType.ONLINE.equals(activityType) ||
+                (locationInfo != null && locationInfo.isValidLocation());
+    }
+
 
     @Hidden
     public ClubCategoryMajor getMajor() {

--- a/src/main/java/com/sideteam/groupsaver/domain/club/dto/response/ClubInfoResponse.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/club/dto/response/ClubInfoResponse.java
@@ -7,6 +7,8 @@ import com.sideteam.groupsaver.domain.club.domain.Club;
 import com.sideteam.groupsaver.domain.club.domain.ClubActivityType;
 import com.sideteam.groupsaver.domain.club.domain.ClubType;
 import com.sideteam.groupsaver.domain.location.domain.Location;
+import com.sideteam.groupsaver.domain.location.domain.Region1Type;
+import com.sideteam.groupsaver.domain.location.dto.response.LocationInfoResponse;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -18,56 +20,35 @@ public record ClubInfoResponse(
         String description,
         Integer memberCurrentNumber,
         Integer memberMaxNumber,
-        String clubType,
+        ClubType clubType,
         String mainImage,
         Long creatorId,
-        String category,
-        String categoryMajor,
-        String categorySub,
+        ClubCategory category,
+        ClubCategoryMajor categoryMajor,
+        ClubCategorySub categorySub,
         Boolean isActive,
         LocalDateTime startAt,
-        String activityType,
-        LocationInfo location
+        ClubActivityType activityType,
+        LocationInfoResponse location
 ) {
-    public record LocationInfo(
-            Long id,
-            String name,
-            String region1,
-            String region2,
-            String region3) {
-        static LocationInfo of(Location location) {
-            return new LocationInfo(location.getId(), location.getName(),
-                    location.getRegion1().getName(), location.getRegion2(), location.getRegion3());
-        }
-    }
-
     public static ClubInfoResponse of(Club club) {
         return ClubInfoResponse.builder()
                 .id(club.getId())
                 .name(club.getName())
                 .memberCurrentNumber(club.getMemberCurrentNumber())
                 .memberMaxNumber(club.getMemberMaxNumber())
-                .clubType(club.getType().getType())
+                .clubType(club.getType())
                 .description(club.getDescription())
-                .category(club.getCategory().getType())
-                .categoryMajor(club.getCategoryMajor().getName())
-                .categorySub(getCategorySub(club.getCategorySub()))
+                .category(club.getCategory())
+                .categoryMajor(club.getCategoryMajor())
+                .categorySub(club.getCategorySub())
                 .mainImage(club.getMainImage())
                 .isActive(club.isActive())
                 .startAt(club.getStartAt())
-                .activityType(club.getActivityType().getActivityType())
+                .activityType(club.getActivityType())
                 .creatorId(club.getCreator().getId())
-                .location(LocationInfo.of(club.getLocation()))
+                .location(LocationInfoResponse.of(club.getLocation()))
                 .build();
-    }
-
-    private static String getCategorySub(ClubCategorySub sub) {
-        if (sub == null) {
-            return null;
-        } else if (sub.isEtc()) {
-            return "기타";
-        }
-        return sub.getName();
     }
 
 }

--- a/src/main/java/com/sideteam/groupsaver/domain/club/repository/ClubMemberRepository.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/club/repository/ClubMemberRepository.java
@@ -15,21 +15,14 @@ import java.util.function.BooleanSupplier;
 
 import static com.sideteam.groupsaver.global.exception.club.ClubErrorCode.CLUB_MEMBER_DO_NOT_HAVE_PERMISSION;
 
-public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
+public interface ClubMemberRepository extends JpaRepository<ClubMember, Long>, ClubMemberRepositoryCustom {
+
     @EntityGraph(attributePaths = {"club.location"}, type = EntityGraph.EntityGraphType.FETCH)
     Page<ClubMember> findByMemberIdAndStatus(Long memberId, ClubMemberStatus status, Pageable pageable);
 
     boolean existsByClubIdAndMemberId(Long clubId, Long memberId);
 
     void deleteByClubIdAndMemberId(Long clubId, Long memberId);
-
-    @Query("SELECT CASE WHEN COUNT(cm) >= c.memberMaxNumber THEN true ELSE false END " +
-            "FROM Club c JOIN ClubMember cm ON c.id = cm.club.id WHERE cm.club.id = :clubId ")
-    boolean hasExceededMemberLimit(Long clubId);
-
-    @Query("SELECT CASE WHEN COUNT(*) >= 1 THEN true ELSE false END " +
-            "FROM Club c JOIN ClubMember cm ON c.id = cm.club.id WHERE cm.club.id = :clubId AND cm.member.id = :memberId AND cm.role = :role")
-    boolean hasClubRole(Long clubId, Long memberId, ClubMemberRole role);
 
     @Query("SELECT cm.member FROM ClubMember cm WHERE cm.club.id = :clubId")
     Page<Member> findAllMembersByClubId(Long clubId, Pageable pageable);

--- a/src/main/java/com/sideteam/groupsaver/domain/club/repository/ClubMemberRepositoryCustom.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/club/repository/ClubMemberRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.sideteam.groupsaver.domain.club.repository;
+
+import com.sideteam.groupsaver.domain.club.domain.ClubMemberRole;
+
+public interface ClubMemberRepositoryCustom {
+    boolean hasExceededMemberLimit(Long clubId);
+
+    boolean hasClubRole(Long clubId, Long memberId, ClubMemberRole role);
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/club/repository/ClubMemberRepositoryCustomImpl.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/club/repository/ClubMemberRepositoryCustomImpl.java
@@ -1,0 +1,40 @@
+package com.sideteam.groupsaver.domain.club.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sideteam.groupsaver.domain.club.domain.ClubMemberRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import static com.sideteam.groupsaver.domain.club.domain.QClub.club;
+import static com.sideteam.groupsaver.domain.club.domain.QClubMember.clubMember;
+
+@RequiredArgsConstructor
+@Repository
+public class ClubMemberRepositoryCustomImpl implements ClubMemberRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public boolean hasExceededMemberLimit(Long clubId) {
+        return Boolean.TRUE.equals(queryFactory
+                .select(clubMember.count()
+                        .goe(club.memberMaxNumber.longValue()))
+                .from(clubMember)
+                .join(clubMember.club).on(clubMember.club.id.eq(clubId))
+                .fetchOne());
+    }
+
+    @Override
+    public boolean hasClubRole(Long clubId, Long memberId, ClubMemberRole role) {
+        return Boolean.TRUE.equals(queryFactory
+                .select(clubMember.count()
+                        .goe(1L))
+                .from(clubMember)
+                .join(clubMember.club).on(clubMember.club.id.eq(clubId))
+                .where(clubMember.member.id.eq(memberId)
+                        .and(clubMember.role.eq(role)))
+                .limit(1)
+                .fetchOne());
+    }
+
+}

--- a/src/main/java/com/sideteam/groupsaver/domain/club/repository/ClubRepositoryCustomImpl.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/club/repository/ClubRepositoryCustomImpl.java
@@ -42,7 +42,7 @@ public class ClubRepositoryCustomImpl implements ClubRepositoryCustom {
 
         List<ClubInfoResponse> clubs = queryFactory
                 .selectFrom(club)
-                .join(club.location, location).fetchJoin()
+                .leftJoin(club.location, location).fetchJoin()
                 .where(hasCategoryAndTextWithin(text, longitude, latitude, radiusMeter, category, categoryMajor, categorySub, type))
                 .orderBy(QueryUtils.getOrderSpecifiers(pageable, club))
                 .offset(pageable.getOffset())

--- a/src/main/java/com/sideteam/groupsaver/domain/club/service/ClubMemberService.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/club/service/ClubMemberService.java
@@ -28,15 +28,13 @@ public class ClubMemberService {
     private final MemberRepository memberRepository;
 
     @Transactional(readOnly = true)
-    @PreAuthorize("isAuthenticated() AND (( #memberId.toString() == principal.username ) " +
-            "AND @clubMemberRepository.existsByClubIdAndMemberId(#clubId, #memberId) " +
-            "OR hasRole('ADMIN'))")
+    @PreAuthorize("@authorityChecker.hasAuthority(#memberId, @clubMemberRepository.isInClub(#clubId, #memberId))")
     public Slice<ClubMemberResponse> getClubMembers(Long clubId, Long memberId, Pageable pageable) {
         return clubMemberRepository.findAllMembersByClubId(clubId, pageable)
                 .map(ClubMemberResponse::from);
     }
 
-    @PreAuthorize("isAuthenticated() AND (( #memberId.toString() == principal.username ) OR hasRole('ADMIN'))")
+    @PreAuthorize("@authorityChecker.hasAuthority(#memberId)")
     public void joinClub(Long clubId, Long memberId, ClubMemberRole role) {
         if (clubMemberRepository.existsByClubIdAndMemberId(clubId, memberId)) {
             throw new BusinessException(CLUB_MEMBER_ALREADY_EXIST, "이미 존재하는 인원 : " + memberId);
@@ -53,14 +51,12 @@ public class ClubMemberService {
         clubMemberRepository.save(clubMember);
     }
 
-    @PreAuthorize("isAuthenticated() AND (( #memberId.toString() == principal.username ) OR hasRole('ADMIN'))")
+    @PreAuthorize("@authorityChecker.hasAuthority(#memberId)")
     public void joinClub(Long clubId, Long memberId) {
         joinClub(clubId, memberId, ClubMemberRole.MEMBER);
     }
 
-    @PreAuthorize("isAuthenticated() AND (( #memberId.toString() == principal.username ) " +
-            " AND @clubMemberRepository.isLeader(#clubId, #memberId) " +
-            " OR hasRole('ADMIN'))")
+    @PreAuthorize("@authorityChecker.hasAuthority(#memberId, @clubMemberRepository.isLeader(#clubId, #memberId))")
     public void leaveClub(Long clubId, Long memberId) {
         clubMemberRepository.deleteByClubIdAndMemberId(clubId, memberId);
     }

--- a/src/main/java/com/sideteam/groupsaver/domain/club/service/ClubService.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/club/service/ClubService.java
@@ -4,15 +4,12 @@ import com.sideteam.groupsaver.domain.club.domain.Club;
 import com.sideteam.groupsaver.domain.club.dto.request.ClubRequest;
 import com.sideteam.groupsaver.domain.club.dto.response.ClubInfoResponse;
 import com.sideteam.groupsaver.domain.club.repository.ClubRepository;
-import com.sideteam.groupsaver.domain.defaultImage.repository.DefaultMainImageRepository;
 import com.sideteam.groupsaver.domain.location.domain.Location;
 import com.sideteam.groupsaver.domain.location.repository.LocationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Random;
 
 @Service
 @RequiredArgsConstructor
@@ -25,32 +22,36 @@ public class ClubService {
 
 
     public ClubInfoResponse createClub(ClubRequest clubRequest) {
-        Location location = locationRepository.getReferenceById(clubRequest.locationInfo().id());
-        Club club = clubRepository.save(Club.of(clubRequest, location));
+        if (clubRequest.locationInfo() != null && clubRequest.locationInfo().isValidLocation()) {
+            Location location = locationRepository.getReferenceById(clubRequest.locationInfo().id());
+            Club club = clubRepository.save(Club.of(clubRequest, location));
+            return ClubInfoResponse.of(club);
+        }
+
+        Club club = clubRepository.save(Club.of(clubRequest));
         return ClubInfoResponse.of(club);
     }
+
 
     @Transactional(readOnly = true)
     public ClubInfoResponse getClubInformation(Long clubId) {
         return ClubInfoResponse.of(clubRepository.findByIdOrThrow(clubId));
     }
 
-    @PreAuthorize("isAuthenticated() AND (( #memberId.toString() == principal.username ) " +
-            " AND @clubMemberRepository.isLeader(#clubId, #memberId) " +
-            " OR hasRole('ADMIN'))")
+    @PreAuthorize("@authorityChecker.hasAuthority(#memberId, @clubMemberRepository.isLeader(#clubId, #memberId))")
     public ClubInfoResponse updateClub(Long clubId, ClubRequest clubRequest, Long memberId) {
         Club club = clubRepository.getReferenceById(clubId);
         club.update(clubRequest);
 
-        Location location = locationRepository.getReferenceById(clubRequest.locationInfo().id());
-        club.updateLocation(location);
+        if (clubRequest.locationInfo() != null && clubRequest.locationInfo().isValidLocation()) {
+            Location location = locationRepository.getReferenceById(clubRequest.locationInfo().id());
+            club.updateLocation(location);
+        }
 
         return ClubInfoResponse.of(club);
     }
 
-    @PreAuthorize("isAuthenticated() AND (( #memberId.toString() == principal.username ) " +
-            " AND @clubMemberRepository.isLeader(#clubId, #memberId) " +
-            " OR hasRole('ADMIN'))")
+    @PreAuthorize("@authorityChecker.hasAuthority(#memberId, @clubMemberRepository.isLeader(#clubId, #memberId))")
     public void deactivateClub(Long clubId, Long memberId) {
         clubRepository.deactivateClub(clubId);
     }

--- a/src/main/java/com/sideteam/groupsaver/domain/join/domain/ClubBookmark.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/join/domain/ClubBookmark.java
@@ -3,7 +3,9 @@ package com.sideteam.groupsaver.domain.join.domain;
 import com.sideteam.groupsaver.domain.club.domain.Club;
 import com.sideteam.groupsaver.domain.member.domain.Member;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
@@ -17,10 +19,12 @@ public class ClubBookmark {
 
     @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
     private Member member;
 
     @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
     private Club club;
 
     public static ClubBookmark of(Member member, Club club) {

--- a/src/main/java/com/sideteam/groupsaver/domain/join/domain/WantClubCategory.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/join/domain/WantClubCategory.java
@@ -6,6 +6,8 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -16,9 +18,12 @@ public class WantClubCategory {
     private Long id;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private ClubCategoryMajor categoryMajor;
 
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
     private Member member;
 
     private WantClubCategory(Member member, ClubCategoryMajor categoryMajor) {

--- a/src/main/java/com/sideteam/groupsaver/domain/location/converter/LocationInfoDeserializer.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/location/converter/LocationInfoDeserializer.java
@@ -35,6 +35,10 @@ public class LocationInfoDeserializer extends JsonDeserializer<LocationInfoReque
         ObjectCodec codec = jsonParser.getCodec();
         JsonNode node = codec.readTree(jsonParser);
 
+        if (node == null) {
+            return LocationInfoRequest.empty();
+        }
+
         JsonNode locationNode = node.get("location");
         if (locationNode != null && !locationNode.isNull()) {
             List<LocationInfoResponse> locationResponses = locationService.searchByName(locationNode.asText());

--- a/src/main/java/com/sideteam/groupsaver/domain/location/domain/Region1Type.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/location/domain/Region1Type.java
@@ -1,5 +1,6 @@
 package com.sideteam.groupsaver.domain.location.domain;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.sideteam.groupsaver.global.exception.ApiErrorCode;
 import com.sideteam.groupsaver.global.exception.BusinessException;
 import com.sideteam.groupsaver.global.util.converter.EnumValue;
@@ -22,15 +23,15 @@ public enum Region1Type implements EnumValue {
     DAEJEON("대전", "대전", 25, "대전"),
     ULSAN("울산", "울산", 26, "울산"),
     SEJONG("세종", "세종", 29, "세종"),
-    GYEONGGI("경기", "경기", 31, "경기"),
-    GANGWON("강원", "강원", 32, "강원"),
+    GYEONGGI("경기", "경기도", 31, "경기"),
+    GANGWON("강원", "강원도", 32, "강원"),
     CHUNGBUK("충북", "충청북도", 33, "충북"),
     CHUNGNAM("충남", "충청남도", 34, "충남"),
     GYUENGBUK("경북", "경상북도", 35, "경북"),
     GYUENGNAM("경남", "경상남도", 36, "경남"),
     JEONBUK("전북", "전라북도", 37, "전북"),
     JEONNAM("전남", "전라남도", 38, "전남"),
-    JEJU("제주", "제주", 39, "제주"),
+    JEJU("제주", "제주도", 39, "제주"),
 
     ;
 
@@ -39,6 +40,11 @@ public enum Region1Type implements EnumValue {
     private final Integer regionCode;
     private final String code;
 
+
+    @JsonValue
+    public String getJsonValue() {
+        return name;
+    }
 
     public static boolean matchesRegion1TypeName(String inputName) {
         return Arrays.stream(Region1Type.values())

--- a/src/main/java/com/sideteam/groupsaver/domain/location/dto/request/LocationInfoRequest.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/location/dto/request/LocationInfoRequest.java
@@ -2,6 +2,7 @@ package com.sideteam.groupsaver.domain.location.dto.request;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.sideteam.groupsaver.domain.location.converter.LocationInfoDeserializer;
+import com.sideteam.groupsaver.domain.location.domain.Region1Type;
 import com.sideteam.groupsaver.domain.location.dto.response.LocationInfoResponse;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -18,17 +19,26 @@ public record LocationInfoRequest(
         @Hidden
         String name,
         @Hidden
-        String region1,
+        Region1Type region1,
         @Hidden
         String region2,
         @Hidden
         String region3,
         Double longitude,
-        Double latitude
+        Double latitude,
+        @Hidden
+        boolean isValidLocation
 ) {
     public static LocationInfoRequest of(LocationInfoResponse locationInfoResponse) {
         return new LocationInfoRequest(locationInfoResponse.id(), locationInfoResponse.name(),
                 locationInfoResponse.region1(), locationInfoResponse.region2(), locationInfoResponse.region3(),
-                locationInfoResponse.longitude(), locationInfoResponse.latitude());
+                locationInfoResponse.longitude(), locationInfoResponse.latitude(), true);
     }
+
+    public static LocationInfoRequest empty() {
+        return new LocationInfoRequest(null, "",
+                null, null, null,
+                null, null, false);
+    }
+
 }

--- a/src/main/java/com/sideteam/groupsaver/domain/location/dto/response/LocationInfoResponse.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/location/dto/response/LocationInfoResponse.java
@@ -1,24 +1,35 @@
 package com.sideteam.groupsaver.domain.location.dto.response;
 
 import com.sideteam.groupsaver.domain.location.domain.Location;
+import com.sideteam.groupsaver.domain.location.domain.Region1Type;
 
 public record LocationInfoResponse(
         Long id,
         String name,
-        String region1,
+        Region1Type region1,
         String region2,
         String region3,
+        String region4,
         Double longitude,
-        Double latitude
+        Double latitude,
+        boolean isValidLocation
 ) {
 
     public static LocationInfoResponse of(Location location) {
+        if (location == null) {
+            return empty();
+        }
         return new LocationInfoResponse(
-                location.getId(),
-                location.getName(),
-                location.getRegion1().getName(), location.getRegion2(), location.getRegion3(),
-                location.getLocationCoordinate().getLongitude(), location.getLocationCoordinate().getLatitude());
+                location.getId(), location.getName(),
+                location.getRegion1(), location.getRegion2(), location.getRegion3(), location.getRegion4(),
+                location.getLocationCoordinate().getLongitude(), location.getLocationCoordinate().getLatitude(),
+                true);
+    }
 
+    public static LocationInfoResponse empty() {
+        return new LocationInfoResponse(null, "",
+                null, null, null, null,
+                null, null, false);
     }
 
 }

--- a/src/main/java/com/sideteam/groupsaver/global/config/RedisConfig.java
+++ b/src/main/java/com/sideteam/groupsaver/global/config/RedisConfig.java
@@ -1,30 +1,30 @@
 package com.sideteam.groupsaver.global.config;
 
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.util.StringUtils;
 
+import static org.springframework.util.StringUtils.hasText;
+
+@RequiredArgsConstructor
 @Configuration
 public class RedisConfig {
 
-    @Value("${spring.data.redis.host}")
-    private String host;
+    private final RedisProperties redisProperties;
 
-    @Value("${spring.data.redis.port}")
-    private int port;
-
-    @Value("${spring.data.redis.password:}")
-    private String password;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(
+                redisProperties.getHost(), redisProperties.getPort());
 
-        if (StringUtils.hasText(password)) {
+        String password = redisProperties.getPassword();
+
+        if (hasText(password)) {
             config.setPassword(password);
         }
         return new LettuceConnectionFactory(config);

--- a/src/main/java/com/sideteam/groupsaver/global/exception/category/CategoryErrorCode.java
+++ b/src/main/java/com/sideteam/groupsaver/global/exception/category/CategoryErrorCode.java
@@ -5,11 +5,14 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @RequiredArgsConstructor
 @Getter
 public enum CategoryErrorCode implements ErrorCode {
+
+    INVALID_CATEGORY(BAD_REQUEST, "찾을 수 없는 모임 분류입니다"),
     CATEGORY_MAJOR_NOT_FOUND(NOT_FOUND, "찾을 수 없는 대분류입니다"),
     CATEGORY_SUB_NOT_FOUND(NOT_FOUND, "찾을 수 없는 소분류입니다"),
     ACTIVITY_TYPE_NOT_FOUND(NOT_FOUND, "찾을 수 없는 활동 분야입니다"),

--- a/src/test/java/com/sideteam/groupsaver/GroupSaverApplicationTests.java
+++ b/src/test/java/com/sideteam/groupsaver/GroupSaverApplicationTests.java
@@ -1,6 +1,6 @@
 package com.sideteam.groupsaver;
 
-import com.sideteam.groupsaver.config.IntegrationSpringBootTest;
+import com.sideteam.groupsaver.utils.context.IntegrationSpringBootTest;
 import org.junit.jupiter.api.Test;
 
 @IntegrationSpringBootTest

--- a/src/test/java/com/sideteam/groupsaver/config/TestRedisConfiguration.java
+++ b/src/test/java/com/sideteam/groupsaver/config/TestRedisConfiguration.java
@@ -1,32 +1,25 @@
 package com.sideteam.groupsaver.config;
 
-import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.boot.test.context.TestConfiguration;
-import redis.embedded.RedisServer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
 
 @TestConfiguration
 public class TestRedisConfiguration {
 
-    private final RedisServer redisServer;
+    private static final String REDIS_DOCKER_IMAGE = "redis:7.2.0-alpine";
 
     public TestRedisConfiguration(RedisProperties redisProperties) {
-        this.redisServer = RedisServer.builder()
-                .port(redisProperties.getPort())
-                .setting("bind 127.0.0.1")
-                .setting("maxmemory 128M")
-                .build();
-    }
 
-    @PostConstruct
-    public void postConstruct() {
-        redisServer.start();
-    }
+        GenericContainer<?> redisContainer = new GenericContainer<>(DockerImageName.parse(REDIS_DOCKER_IMAGE))
+                .withExposedPorts(redisProperties.getPort())
+                .withReuse(true);
 
-    @PreDestroy
-    public void preDestroy() {
-        redisServer.stop();
+        redisContainer.start();
+
+        redisProperties.setHost(redisContainer.getHost());
+        redisProperties.setPort(redisContainer.getFirstMappedPort());
     }
 
 }

--- a/src/test/java/com/sideteam/groupsaver/domain/club/repository/ClubMemberRepositoryTest.java
+++ b/src/test/java/com/sideteam/groupsaver/domain/club/repository/ClubMemberRepositoryTest.java
@@ -1,0 +1,117 @@
+package com.sideteam.groupsaver.domain.club.repository;
+
+import com.sideteam.groupsaver.domain.club.domain.Club;
+import com.sideteam.groupsaver.domain.club.domain.ClubMember;
+import com.sideteam.groupsaver.domain.club.domain.ClubMemberRole;
+import com.sideteam.groupsaver.domain.member.domain.Member;
+import com.sideteam.groupsaver.domain.member.repository.MemberRepository;
+import com.sideteam.groupsaver.utils.context.DataJpaTestcontainersTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static com.sideteam.groupsaver.utils.provider.ClubProvider.createClub;
+import static com.sideteam.groupsaver.utils.provider.MemberProvider.createMember;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTestcontainersTest
+class ClubMemberRepositoryTest {
+
+    @Autowired
+    private ClubMemberRepository clubMemberRepository;
+
+    @Autowired
+    private ClubRepository clubRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private final static int MEMBER_LIMIT = 5;
+
+    private Club club;
+
+
+    @BeforeEach
+    void setup() {
+        club = clubRepository.saveAndFlush(createClub(MEMBER_LIMIT));
+
+        // 모임에 멤버 추가, 모임 최대 인원에서 -1 만큼 추가
+        List<Member> members = memberRepository.saveAllAndFlush(IntStream.range(0, MEMBER_LIMIT - 1)
+                .mapToObj(i -> createMember())
+                .toList());
+
+        clubMemberRepository.saveAllAndFlush(members.stream()
+                .map(member -> ClubMember.of(club, member, ClubMemberRole.MEMBER))
+                .toList());
+    }
+
+
+    @AfterEach
+    void tearDown() {
+        clubMemberRepository.deleteAll();
+        memberRepository.deleteAll();
+        clubRepository.deleteAll();
+    }
+
+
+    @Test
+    @DisplayName("모임 인원이 가득 찼는지 확인")
+    void hasExceededMemberLimit() {
+        // given
+        Member newMember = memberRepository.save(createMember());
+        clubMemberRepository.save(ClubMember.of(club, newMember, ClubMemberRole.MEMBER));
+
+        // when
+        final boolean hasExceededMemberLimit = clubMemberRepository.hasExceededMemberLimit(club.getId());
+
+        // then
+        assertTrue(hasExceededMemberLimit);
+    }
+
+    @Test
+    @DisplayName("해당 모임의 멤버가 역할이 있는지 확인")
+    void hasClubRole() {
+        // given
+        Member newMember = memberRepository.save(createMember());
+        clubMemberRepository.save(ClubMember.of(club, newMember, ClubMemberRole.MEMBER));
+
+        // when
+        final boolean hasClubRole = clubMemberRepository.hasClubRole(club.getId(), newMember.getId(), ClubMemberRole.MEMBER);
+
+        // then
+        assertTrue(hasClubRole);
+    }
+
+    @Test
+    @DisplayName("해당 모임의 멤버가 역할이 없는지 확인")
+    void givenMember_whenHasClubRole_thenFalse() {
+        // given
+        Member newMember = memberRepository.save(createMember());
+        clubMemberRepository.save(ClubMember.of(club, newMember, ClubMemberRole.MEMBER));
+
+        // when
+        final boolean hasClubRole = clubMemberRepository.hasClubRole(club.getId(), newMember.getId(), ClubMemberRole.LEADER);
+
+        // then
+        assertFalse(hasClubRole);
+    }
+
+    @Test
+    @DisplayName("해당 모임에 없는 멤버가 역할이 없는지 확인")
+    void givenMemberNotInClub_whenHasClubRole_thenFalse() {
+        // given
+        Member newMember = memberRepository.save(createMember());
+
+        // when
+        final boolean hasClubRole = clubMemberRepository.hasClubRole(club.getId(), newMember.getId(), ClubMemberRole.LEADER);
+
+        // then
+        assertFalse(hasClubRole);
+    }
+
+}

--- a/src/test/java/com/sideteam/groupsaver/domain/firebase/service/FcmTokenServiceTest.java
+++ b/src/test/java/com/sideteam/groupsaver/domain/firebase/service/FcmTokenServiceTest.java
@@ -1,7 +1,7 @@
 package com.sideteam.groupsaver.domain.firebase.service;
 
 import com.google.firebase.messaging.FirebaseMessagingException;
-import com.sideteam.groupsaver.config.IntegrationSpringBootTest;
+import com.sideteam.groupsaver.utils.context.IntegrationSpringBootTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 

--- a/src/test/java/com/sideteam/groupsaver/integration/auth/AuthIntegrationTest.java
+++ b/src/test/java/com/sideteam/groupsaver/integration/auth/AuthIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.sideteam.groupsaver.integration.auth;
 
-import com.sideteam.groupsaver.config.IntegrationSpringBootTest;
 import com.sideteam.groupsaver.domain.auth.dto.request.LoginRequest;
 import com.sideteam.groupsaver.domain.auth.dto.request.SignupRequest;
 import com.sideteam.groupsaver.domain.auth.dto.request.TokenRefreshRequest;
@@ -10,9 +9,7 @@ import com.sideteam.groupsaver.domain.auth.service.AuthSignupService;
 import com.sideteam.groupsaver.domain.auth.service.AuthTokenService;
 import com.sideteam.groupsaver.domain.member.repository.MemberRepository;
 import com.sideteam.groupsaver.global.auth.refresh_token.RefreshTokenRepository;
-import com.sideteam.groupsaver.global.exception.BusinessException;
-import com.sideteam.groupsaver.global.exception.ErrorCode;
-import com.sideteam.groupsaver.global.exception.member.MemberErrorCode;
+import com.sideteam.groupsaver.utils.context.IntegrationSpringBootTest;
 import com.sideteam.groupsaver.utils.provider.MemberProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.*;

--- a/src/test/java/com/sideteam/groupsaver/utils/context/DataJpaTestcontainersTest.java
+++ b/src/test/java/com/sideteam/groupsaver/utils/context/DataJpaTestcontainersTest.java
@@ -1,0 +1,28 @@
+package com.sideteam.groupsaver.utils.context;
+
+import com.sideteam.groupsaver.config.TestRedisConfiguration;
+import com.sideteam.groupsaver.global.config.QueryDslConfig;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.lang.annotation.*;
+
+/**
+ * 리포지터리 테스트 환경에 맞는 설정을 사용하도록 지원하는 어노테이션
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+
+@ActiveProfiles("test")
+@Testcontainers
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE) // H2 사용 금지
+@Import({RedisProperties.class, TestRedisConfiguration.class, QueryDslConfig.class})
+public @interface DataJpaTestcontainersTest {
+}

--- a/src/test/java/com/sideteam/groupsaver/utils/context/IntegrationSpringBootTest.java
+++ b/src/test/java/com/sideteam/groupsaver/utils/context/IntegrationSpringBootTest.java
@@ -1,5 +1,6 @@
-package com.sideteam.groupsaver.config;
+package com.sideteam.groupsaver.utils.context;
 
+import com.sideteam.groupsaver.config.TestRedisConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -13,7 +14,7 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 
-@ActiveProfiles(profiles = "test")
+@ActiveProfiles("test")
 @Testcontainers
 @SpringBootTest(classes = TestRedisConfiguration.class)
 public @interface IntegrationSpringBootTest {

--- a/src/test/java/com/sideteam/groupsaver/utils/provider/ClubProvider.java
+++ b/src/test/java/com/sideteam/groupsaver/utils/provider/ClubProvider.java
@@ -18,6 +18,19 @@ public final class ClubProvider {
                 .category(createClubCategory())
                 .categoryMajor(createClubCategoryMajor())
                 .activityType(createClubActivityType())
+                .memberMaxNumber(10_000)
+                .build();
+    }
+
+    public static Club createClub(int maxMemberCount) {
+        return Club.builder()
+                .name("test-club-" + UUID.randomUUID())
+                .description("test-description " + UUID.randomUUID())
+                .type(createClubType())
+                .category(createClubCategory())
+                .categoryMajor(createClubCategoryMajor())
+                .activityType(createClubActivityType())
+                .memberMaxNumber(maxMemberCount)
                 .build();
     }
 


### PR DESCRIPTION
## 이슈 연결

- close #69 

## 구현한 API

- 없습니다

## 작업 사항

- 온라인 모임에 기본 주소가 저장되지 않도록 수정
- 모임 위치 찾을 때, left join 으로 변경
- 모임 정보 반환시 위치가 없다면 빈 위치 dto 객체 반환하도록 수정
- `@JsonValue`을 추가해서 enum -> dto 변환과의 관심사 분리

### 모임 생성 예시

1. 온라인 모임의 경우, `"locationInfo"` 생략 가능
```json
{
  "categoryMajor": "사이드 프로젝트",
  "type": "단기",
  "name": "내 모임 1",
  "activityType": "온라인",
  "memberMaxNumber": 10,
  "startAt": "2023-12-04 12:00:00",
  "mainImage": "value_for_mainImage",
  "description": "value_for_description"
}
```

2. 오프라인 모임의 경우, 생략 불가
```json
{
  "locationInfo": {
    "location": "경기도 성남"
  },
  "categoryMajor": "사이드 프로젝트",
  "type": "단기",
  "name": "내 모임 2",
  "activityType": "오프라인",
  "memberMaxNumber": 10,
  "startAt": "2023-12-04 12:00:00",
  "mainImage": "value_for_mainImage",
  "description": "value_for_description"
}
```

3. 오프라인 모임이지만 기본 주소를 원하는 경우, "locationInfo"에 null이 아닌 빈 객체를 넣으면 됨
```json
{
  "locationInfo": {
  },
  "categoryMajor": "사이드 프로젝트",
  "type": "단기",
  "name": "내 모임 3",
  "activityType": "오프라인",
  "memberMaxNumber": 10,
  "startAt": "2023-12-04 12:00:00",
  "mainImage": "value_for_mainImage",
  "description": "value_for_description"
}
```
### 카테고리가 기타인 모임 생성 예시

`문화 · 예술_기타`, `음악 · 악기_기타`, `운동 · 스포츠_기타` 등등 
각 major 카테고리내에 해당하는 이름 뒤에 `_기타`를 붙인 sub 카테고리로 요청보내주시면 감사하겠습니다.

```json
{
   "categorySub": "운동 · 스포츠_기타",
  "type": "단기",
  "name": "내 음악 모임",
  "activityType": "온라인",
  "memberMaxNumber": 10,
  "startAt": "2023-12-04 12:00:00",
  "mainImage": "value_for_mainImage",
  "description": "value_for_description"
}
```

## 리뷰 요청 사항

보시고 피드백 부탁드립니다!
