### PR TITLE
마이페이지 모임 카테고리 반환값 분리 및 시간 관련 포멧 통일

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ out/
 .DS_Store
 
 /src/main/generated/
+/src/main/resources/firebase/*
+/src/main/resources/.env
+
+/src/test/resources/application-test.yml
+/src/test/resources/firebase-config.json

--- a/src/main/java/com/sideteam/groupsaver/domain/member/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/member/dto/response/MyProfileResponse.java
@@ -15,7 +15,8 @@ public record MyProfileResponse(
         LocalDate birth,
         String profileImageUrl,
         JobMajor jobMajor,
-        List<ClubCategoryMajor> clubCategories,
+        List<ClubCategoryMajor> develops,
+        List<ClubCategoryMajor> hobbies,
         long myClubCount,
         long clubBookmarkCount
 ) {

--- a/src/main/java/com/sideteam/groupsaver/domain/member/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/member/repository/MemberRepositoryCustomImpl.java
@@ -5,6 +5,7 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sideteam.groupsaver.domain.category.domain.ClubCategory;
 import com.sideteam.groupsaver.domain.category.domain.ClubCategoryMajor;
 import com.sideteam.groupsaver.domain.member.domain.MemberActive;
 import com.sideteam.groupsaver.domain.member.dto.response.MyProfileResponse;
@@ -14,6 +15,8 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+import static com.sideteam.groupsaver.domain.category.domain.ClubCategory.DEVELOP;
+import static com.sideteam.groupsaver.domain.category.domain.ClubCategory.HOBBY;
 import static com.sideteam.groupsaver.domain.club.domain.QClubMember.clubMember;
 import static com.sideteam.groupsaver.domain.join.domain.QClubBookmark.clubBookmark;
 import static com.sideteam.groupsaver.domain.join.domain.QWantClubCategory.wantClubCategory;
@@ -37,6 +40,8 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
                 .from(clubBookmark)
                 .where(clubBookmark.member.id.eq(memberId));
 
+        List<ClubCategoryMajor> clubCategoryMajors = findAllCategoryMajorByMemberId(memberId);
+
         return queryFactory.select(new QMyProfileResponse(
                         member.id,
                         member.phoneNumber,
@@ -45,7 +50,8 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
                         member.birth,
                         member.profileUrl,
                         member.jobCategory,
-                        Expressions.constant(findAllCategoryMajorByMemberId(memberId)),
+                        Expressions.constant(filterCategories(clubCategoryMajors, DEVELOP)),
+                        Expressions.constant(filterCategories(clubCategoryMajors, HOBBY)),
                         ExpressionUtils.as(clubMemberCountSubQuery, "myClubCount"),
                         ExpressionUtils.as(clubBookmarkCountSubQuery, "clubBookmarkCount")
                 ))
@@ -61,6 +67,12 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
                 .from(wantClubCategory)
                 .where(wantClubCategory.member.id.eq(memberId))
                 .fetch();
+    }
+
+    private List<ClubCategoryMajor> filterCategories(List<ClubCategoryMajor> clubCategoryMajors, ClubCategory clubCategory) {
+        return clubCategoryMajors.stream()
+                .filter(clubCategoryMajor -> clubCategoryMajor.getCategory().equals(clubCategory))
+                .toList();
     }
 
 }

--- a/src/main/java/com/sideteam/groupsaver/global/config/ObjectMapperConfig.java
+++ b/src/main/java/com/sideteam/groupsaver/global/config/ObjectMapperConfig.java
@@ -1,9 +1,17 @@
 package com.sideteam.groupsaver.global.config;
 
+import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static java.time.format.DateTimeFormatter.ofPattern;
 
 @Configuration
 public class ObjectMapperConfig {
@@ -11,8 +19,18 @@ public class ObjectMapperConfig {
     @Bean
     public ObjectMapper objectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.registerModule(javaDateTimeModule());
         return objectMapper;
+    }
+
+
+    private Module javaDateTimeModule() {
+        SimpleModule dateTimeModule = new SimpleModule();
+
+        dateTimeModule.addSerializer(LocalDate.class, new LocalDateSerializer(ofPattern("yyyy-MM-dd")));
+        dateTimeModule.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer(ofPattern("yyyy-MM-dd HH:mm:ss")));
+
+        return dateTimeModule;
     }
 
 }

--- a/src/main/java/com/sideteam/groupsaver/global/config/ObjectMapperConfig.java
+++ b/src/main/java/com/sideteam/groupsaver/global/config/ObjectMapperConfig.java
@@ -3,6 +3,7 @@ package com.sideteam.groupsaver.global.config;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import org.springframework.context.annotation.Bean;
@@ -19,12 +20,13 @@ public class ObjectMapperConfig {
     @Bean
     public ObjectMapper objectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(javaDateTimeModule());
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.registerModule(customTimeModule());
         return objectMapper;
     }
 
 
-    private Module javaDateTimeModule() {
+    private Module customTimeModule() {
         SimpleModule dateTimeModule = new SimpleModule();
 
         dateTimeModule.addSerializer(LocalDate.class, new LocalDateSerializer(ofPattern("yyyy-MM-dd")));

--- a/src/test/java/com/sideteam/groupsaver/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/sideteam/groupsaver/domain/member/repository/MemberRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.sideteam.groupsaver.domain.member.repository;
 
+import com.sideteam.groupsaver.domain.category.domain.ClubCategory;
 import com.sideteam.groupsaver.domain.category.domain.ClubCategoryMajor;
 import com.sideteam.groupsaver.domain.club.domain.Club;
 import com.sideteam.groupsaver.domain.club.domain.ClubMember;
@@ -16,6 +17,7 @@ import com.sideteam.groupsaver.utils.context.DataJpaTestcontainersTest;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -42,7 +44,8 @@ class MemberRepositoryTest {
     private ClubBookmarkRepository clubBookmarkRepository;
 
     private long memberId;
-    private final List<ClubCategoryMajor> wantCategories = List.of(ClubCategoryMajor.BOOK, ClubCategoryMajor.CRAFT);
+    private final List<ClubCategoryMajor> wantCategories = List.of(
+            ClubCategoryMajor.CHANGE, ClubCategoryMajor.BOOK, ClubCategoryMajor.CRAFT, ClubCategoryMajor.ETC_HOBBY);
 
 
     @BeforeEach
@@ -79,12 +82,24 @@ class MemberRepositoryTest {
         clubBookmarkRepository.deleteAll();
     }
 
+
     @Test
+    @DisplayName("내 프로필 조회 성공 - 회원 ID로 조회")
     void findMyProfileByMemberId() {
+        // given
+        final List<ClubCategoryMajor> expectedDevelops = wantCategories.stream()
+                .filter(category -> category.getCategory().equals(ClubCategory.DEVELOP)).toList();
+
+        final List<ClubCategoryMajor> expectedHobbies = wantCategories.stream()
+                .filter(category -> category.getCategory().equals(ClubCategory.HOBBY)).toList();
+
+        // when
         MyProfileResponse myProfileResponse = memberRepository.findMyProfileByMemberId(memberId);
 
+        // then
         assertThat(myProfileResponse.myClubCount()).isEqualTo(1);
-        assertThat(myProfileResponse.clubCategories()).isEqualTo(wantCategories);
+        assertThat(myProfileResponse.develops()).isEqualTo(expectedDevelops);
+        assertThat(myProfileResponse.hobbies()).isEqualTo(expectedHobbies);
         assertThat(myProfileResponse.clubBookmarkCount()).isEqualTo(2);
     }
 


### PR DESCRIPTION
## 이슈 연결

- close #72 

## 구현한 API

- 없습니다.

## 작업 사항

### 1. 사용자가 선택한 카테고리를 자기계발과 취미로 나눔

- 기존

```json
"clubCategories": [ "사이드 프로젝트", "공예", "여행 · 드라이브" ],
```

- 수정 후

```json
"develops": [ "사이드 프로젝트" ],
"hobbies": [ "공예", "여행 · 드라이브" ],
```

### 2. 시간 반환 포멧 수정

|         | 포멧                  | 예시                  |
|---------|---------------------|---------------------|
| 날짜      | yyyy-MM-dd          | 2023-12-04          |
| 날짜 및 시간 | yyyy-MM-dd HH:mm:ss | 2023-12-04 12:00:00 |


## 리뷰 요청 사항

