### PR TITLE
탈퇴시 회원정보 삭제

### DIFF
--- a/src/main/java/com/sideteam/groupsaver/domain/member/domain/Member.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/member/domain/Member.java
@@ -61,7 +61,7 @@ public class Member extends BaseTimeEntity {
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, orphanRemoval = true)
     private final List<WantClubCategory> wantClubCategories = new ArrayList<>();
 
-    @OneToMany(mappedBy = "reportedMember", fetch = FetchType.LAZY, orphanRemoval = true)
+    @OneToMany(mappedBy = "reportedMember", fetch = FetchType.LAZY)
     private final List<ReportUser> reports = new ArrayList<>();
 
     @Enumerated(STRING)

--- a/src/main/java/com/sideteam/groupsaver/domain/member/domain/Member.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/member/domain/Member.java
@@ -61,7 +61,7 @@ public class Member extends BaseTimeEntity {
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, orphanRemoval = true)
     private final List<WantClubCategory> wantClubCategories = new ArrayList<>();
 
-    @OneToMany(mappedBy = "reportedMember", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "reportedMember", fetch = FetchType.LAZY, orphanRemoval = true)
     private final List<ReportUser> reports = new ArrayList<>();
 
     @Enumerated(STRING)
@@ -112,10 +112,6 @@ public class Member extends BaseTimeEntity {
 
     public void suspend() {
         this.activeStatus = MemberActive.SUSPEND;
-    }
-
-    public void withdraw() {
-        this.activeStatus = MemberActive.EXIT;
     }
 
 }

--- a/src/main/java/com/sideteam/groupsaver/domain/member/domain/MemberActive.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/member/domain/MemberActive.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum MemberActive {
     ACTIVE("활동중"),
-    EXIT("탈퇴"),
     SUSPEND("정지"),
     ;
 

--- a/src/main/java/com/sideteam/groupsaver/domain/member/service/MemberUpdateService.java
+++ b/src/main/java/com/sideteam/groupsaver/domain/member/service/MemberUpdateService.java
@@ -22,8 +22,7 @@ public class MemberUpdateService {
 
     @PreAuthorize("@authorityChecker.hasAuthority(#memberId)")
     public void withdrawMember(Long memberId) {
-        Member member = memberRepository.findByIdOrThrow(memberId);
-        member.withdraw();
+        memberRepository.deleteById(memberId);
     }
 
 }


### PR DESCRIPTION
## 이슈 연결

- #77 

## 구현한 API

- x

## 작업 사항
회원 탈퇴시 회원정보 삭제
그로 인해 activeStatus.EXIT 상태 삭제

기획시 이용약관에 탈퇴시 회원정보를 바로 삭제해야하기 때문에 바로 삭제 (단, 특정상황시에는 저장(부정고객 등))

## 리뷰 요청 사항

